### PR TITLE
implement USE_EMULATED_VAOS compile flag

### DIFF
--- a/fgOpenGL/BackendGL.h
+++ b/fgOpenGL/BackendGL.h
@@ -43,9 +43,9 @@ namespace GL {
     static FG_Err DrawRect(FG_Backend* self, void* window, FG_Rect* area, FG_Rect* corners, FG_Color fillColor,
                            float border, FG_Color borderColor, float blur, FG_Asset* asset, float rotate, float z,
                            FG_BlendState* blend);
-    static FG_Err DrawCircle(FG_Backend* self, void* window, FG_Rect* area, FG_Vec angles, FG_Color fillColor,
-                             float border, FG_Color borderColor, float blur, float innerRadius, float innerBorder,
-                             FG_Asset* asset, float rotate, FG_BlendState* blend);
+    static FG_Err DrawCircle(FG_Backend* self, void* window, FG_Rect* area, FG_Vec angles, FG_Color fillColor, float border,
+                             FG_Color borderColor, float blur, float innerRadius, float innerBorder, FG_Asset* asset,
+                             float rotate, FG_BlendState* blend);
     static FG_Err DrawTriangle(FG_Backend* self, void* window, FG_Rect* area, FG_Rect* corners, FG_Color fillColor,
                                float border, FG_Color borderColor, float blur, FG_Asset* asset, float rotate, float z,
                                FG_BlendState* blend);
@@ -91,8 +91,8 @@ namespace GL {
     static FG_Err GetDisplayWindow(FG_Backend* self, void* window, FG_Display* out);
     static void* CreateWindowGL(FG_Backend* self, FG_MsgReceiver* element, void* display, FG_Vec* pos, FG_Vec* dim,
                                 const char* caption, uint64_t flags, void* context);
-    static FG_Err SetWindowGL(FG_Backend* self, void* window, FG_MsgReceiver* element, void* display, FG_Vec* pos, FG_Vec* dim,
-                              const char* caption, uint64_t flags);
+    static FG_Err SetWindowGL(FG_Backend* self, void* window, FG_MsgReceiver* element, void* display, FG_Vec* pos,
+                              FG_Vec* dim, const char* caption, uint64_t flags);
     static FG_Err DestroyWindow(FG_Backend* self, void* window);
     static FG_Err BeginDraw(FG_Backend* self, void* window, FG_Rect* area);
     static FG_Err EndDraw(FG_Backend* self, void* window);
@@ -138,13 +138,13 @@ namespace GL {
       v[2].posUV[1] = area.bottom;
       v[2].posUV[2] = uv.left / x;
       v[2].posUV[3] = uv.bottom / y;
-      
+
       v[3].posUV[0] = area.right;
       v[3].posUV[1] = area.bottom;
       v[3].posUV[2] = uv.right / x;
       v[3].posUV[3] = uv.bottom / y;
     }
-    void _drawStandard(GLuint shader, GLuint vao, float (&proj)[4][4], const FG_Rect& area, const FG_Rect& corners,
+    void _drawStandard(GLuint shader, VAO* vao, float (&proj)[4][4], const FG_Rect& area, const FG_Rect& corners,
                        FG_Color fillColor, float border, FG_Color borderColor, float blur, float rotate, float z);
     static void _flushbatchdraw(Backend* backend, Context* context, Font* font);
 

--- a/fgOpenGL/Context.h
+++ b/fgOpenGL/Context.h
@@ -12,6 +12,7 @@
 #include "Layer.h"
 #include "Shader.h"
 #include "Asset.h"
+#include "VAO.h"
 #include <vector>
 #include <utility>
 
@@ -25,7 +26,7 @@ namespace GL {
 
   KHASH_DECLARE(tex, const Asset*, GLuint);
   KHASH_DECLARE(shader, const Shader*, GLuint);
-  KHASH_DECLARE(vao, ShaderAsset, GLuint);
+  KHASH_DECLARE(vao, ShaderAsset, VAO*);
   KHASH_DECLARE(font, const Font*, uint64_t);
   KHASH_DECLARE(glyph, uint32_t, char);
 
@@ -53,17 +54,15 @@ namespace GL {
     void SetDim(const FG_Vec& dim);
     GLuint LoadAsset(Asset* asset);
     GLuint LoadShader(Shader* shader);
-    GLuint LoadVAO(Shader* shader, Asset* asset);
+    VAO* LoadVAO(Shader* shader, Asset* asset);
     bool CheckGlyph(uint32_t g);
     void AddGlyph(uint32_t g);
     GLuint GetFontTexture(const Font* font);
     bool CheckFlush(GLintptr bytes) { return (_bufferoffset + bytes > BATCH_BYTES); }
     void ApplyBlend(const FG_BlendState* blend);
-    virtual void DirtyRect(const FG_Rect* rect) { }
+    virtual void DirtyRect(const FG_Rect* rect) {}
     inline Backend* GetBackend() const { return _backend; }
-    float (&GetProjection())[4][4] {
-      return _layers.size() > 0 ? _layers.back()->proj : proj;
-    }
+    float (&GetProjection())[4][4] { return _layers.size() > 0 ? _layers.back()->proj : proj; }
     float proj[4][4];
 
     static GLenum BlendOp(uint8_t op);
@@ -77,12 +76,12 @@ namespace GL {
     GLuint _circleshader;
     GLuint _trishader;
     GLuint _lineshader;
-    GLuint _quadobject;
+    VAO* _quadobject;
     GLuint _quadbuffer;
-    GLuint _imageobject;
+    VAO* _imageobject;
     GLuint _imagebuffer;
     GLuint _imageindices;
-    GLuint _lineobject;
+    VAO* _lineobject;
     GLuint _linebuffer;
     FG_BlendState _lastblend;
 
@@ -91,8 +90,6 @@ namespace GL {
     static const FG_BlendState DEFAULT_BLEND;
 
   protected:
-    GLuint _createVAO(GLuint shader, const FG_ShaderParameter* parameters, size_t n_parameters, GLuint buffer,
-                      size_t stride, GLuint indices);
     GLuint _createBuffer(size_t stride, size_t count, const void* init);
     GLuint _genIndices(size_t num);
 

--- a/fgOpenGL/VAO.cpp
+++ b/fgOpenGL/VAO.cpp
@@ -1,0 +1,72 @@
+
+#include "BackendGL.h"
+#include "glad/gl.h"
+#include <string.h>
+#include <memory>
+#include "VAO.h"
+
+using namespace GL;
+
+VAO::VAO(Backend* backend, GLuint shader, const FG_ShaderParameter* parameters, size_t n_parameters, GLuint buffer,
+         size_t stride, GLuint indices) :
+  _backend(backend)
+{
+  glGenVertexArrays(1, &_vaoID);
+  _backend->LogError("glGenVertexArrays");
+  glBindVertexArray(_vaoID);
+  _backend->LogError("glBindVertexArray");
+  glBindBuffer(GL_ARRAY_BUFFER, buffer);
+  _backend->LogError("glBindBuffer");
+
+  if(indices)
+  {
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indices);
+    _backend->LogError("glBindBuffer");
+  }
+
+  GLuint offset = 0;
+  for(size_t i = 0; i < n_parameters; ++i)
+  {
+    auto loc = glGetAttribLocation(shader, parameters[i].name);
+    _backend->LogError("glGetAttribLocation");
+    glEnableVertexAttribArray(loc);
+    _backend->LogError("glEnableVertexAttribArray");
+    size_t sz   = Context::GetMultiCount(parameters[i].length, parameters[i].multi);
+    GLenum type = 0;
+    switch(parameters->type)
+    {
+    case FG_ShaderType_FLOAT: type = GL_FLOAT; break;
+    case FG_ShaderType_INT: type = GL_INT; break;
+    case FG_ShaderType_UINT: type = GL_UNSIGNED_INT; break;
+    }
+
+    glVertexAttribPointer(loc, sz, type, GL_FALSE, stride, (void*)offset);
+    offset += Context::GetBytes(type) * sz;
+    _backend->LogError("glVertexAttribPointer");
+  }
+
+  glBindVertexArray(0);
+  _backend->LogError("glBindVertexArray");
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  _backend->LogError("glBindBuffer");
+  if(indices)
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+}
+
+VAO::~VAO()
+{
+  glDeleteVertexArrays(1, &_vaoID);
+  _backend->LogError("glDeleteVertexArrays");
+}
+
+void VAO::Bind()
+{
+  glBindVertexArray(_vaoID);
+  _backend->LogError("glBindVertexArray");
+}
+
+void VAO::Unbind()
+{
+  glBindVertexArray(0);
+  _backend->LogError("glBindVertexArray");
+}

--- a/fgOpenGL/VAO.cpp
+++ b/fgOpenGL/VAO.cpp
@@ -7,6 +7,8 @@
 
 using namespace GL;
 
+#ifndef USE_EMULATED_VAOS
+
 VAO::VAO(Backend* backend, GLuint shader, const FG_ShaderParameter* parameters, size_t n_parameters, GLuint buffer,
          size_t stride, GLuint indices) :
   _backend(backend)
@@ -70,3 +72,69 @@ void VAO::Unbind()
   glBindVertexArray(0);
   _backend->LogError("glBindVertexArray");
 }
+
+#else
+
+VAO::VAO(Backend* backend, GLuint shader, const FG_ShaderParameter* parameters, size_t n_parameters, GLuint buffer,
+         size_t stride, GLuint indices) :
+  _n_attribs(n_parameters), _vertexBuffer(buffer), _stride(stride), _indexBuffer(indices), _backend(backend)
+{
+  _attribs = new VAO::VertexAttrib[n_parameters];
+
+  for(size_t i = 0; i < n_parameters; ++i)
+  {
+    _attribs[i].location = glGetAttribLocation(shader, parameters[i].name);
+    _backend->LogError("glGetAttribLocation");
+
+    _attribs[i].numElements = Context::GetMultiCount(parameters[i].length, parameters[i].multi);
+    switch(parameters->type)
+    {
+    case FG_ShaderType_FLOAT: _attribs[i].type = GL_FLOAT; break;
+    case FG_ShaderType_INT: _attribs[i].type = GL_INT; break;
+    case FG_ShaderType_UINT: _attribs[i].type = GL_UNSIGNED_INT; break;
+    }
+  }
+}
+
+VAO::~VAO() { delete[] _attribs; }
+
+void VAO::Bind()
+{
+  glBindBuffer(GL_ARRAY_BUFFER, _vertexBuffer);
+  _backend->LogError("glBindBuffer");
+  if(_indexBuffer != 0)
+  {
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _indexBuffer);
+    _backend->LogError("glBindBuffer");
+  }
+
+  GLuint offset = 0;
+  for(size_t i = 0; i < _n_attribs; ++i)
+  {
+    glEnableVertexAttribArray(_attribs[i].location);
+    _backend->LogError("glEnableVertexAttribArray");
+
+    glVertexAttribPointer(_attribs[i].location, _attribs[i].numElements, _attribs[i].type, GL_FALSE, _stride,
+                          (void*)offset);
+    _backend->LogError("glVertexAttribPointer");
+    offset += Context::GetBytes(_attribs[i].type) * _attribs[i].numElements;
+  }
+}
+
+void VAO::Unbind()
+{
+  for(size_t i = 0; i < _n_attribs; ++i)
+  {
+    glDisableVertexAttribArray(_attribs[i].location);
+    _backend->LogError("glDisableVertexAttribArray");
+  }
+
+  if(_indexBuffer != 0)
+  {
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _indexBuffer);
+    _backend->LogError("glBindBuffer");
+  }
+  glBindBuffer(GL_ARRAY_BUFFER, _vertexBuffer);
+  _backend->LogError("glBindBuffer");
+}
+#endif

--- a/fgOpenGL/VAO.cpp
+++ b/fgOpenGL/VAO.cpp
@@ -131,10 +131,10 @@ void VAO::Unbind()
 
   if(_indexBuffer != 0)
   {
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _indexBuffer);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     _backend->LogError("glBindBuffer");
   }
-  glBindBuffer(GL_ARRAY_BUFFER, _vertexBuffer);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
   _backend->LogError("glBindBuffer");
 }
 #endif

--- a/fgOpenGL/VAO.h
+++ b/fgOpenGL/VAO.h
@@ -2,6 +2,7 @@
 #ifndef GL__VAO_H
 #define GL__VAO_H
 
+#include "backend.h"
 #include "glad/gl.h"
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
@@ -14,13 +15,44 @@ namespace GL {
   class VAO
   {
   private:
+#ifndef USE_EMULATED_VAOS
+    /// OpenGL object ID of VertexArrayObject
     GLuint _vaoID;
+#else
+    class VertexAttrib
+    {
+    public:
+      /// Index for this attribute used by the GLSL vertex shader
+      GLuint location;
+
+      /// Number of elements per vertex. For example, a position attribute specifying XYZ would have numElements = 3.
+      GLint numElements;
+
+      /// OpenGL datatype of attribute elements. GL_FLOAT, GL_INT, GL_UNSIGNED_INT, etc.
+      GLenum type;
+    };
+
+    size_t _n_attribs;
+
+    VertexAttrib* _attribs;
+
+    /// Total size in bytes of all vertex attributes
+    size_t _stride;
+
+    /// OpenGL object ID of underlying vertex buffer for the VAO
+    GLuint _vertexBuffer;
+
+    /// OpenGL object ID of underlying index buffer for the VAO
+    GLuint _indexBuffer;
+#endif
+
     Backend* _backend;
 
   public:
     VAO(Backend* backend, GLuint shader, const FG_ShaderParameter* parameters, size_t n_parameters, GLuint buffer,
         size_t stride, GLuint indices);
     ~VAO();
+
     void Bind();
     void Unbind();
   };

--- a/fgOpenGL/VAO.h
+++ b/fgOpenGL/VAO.h
@@ -1,0 +1,29 @@
+
+#ifndef GL__VAO_H
+#define GL__VAO_H
+
+#include "glad/gl.h"
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
+#include <vector>
+#include <utility>
+
+namespace GL {
+  class Backend;
+
+  class VAO
+  {
+  private:
+    GLuint _vaoID;
+    Backend* _backend;
+
+  public:
+    VAO(Backend* backend, GLuint shader, const FG_ShaderParameter* parameters, size_t n_parameters, GLuint buffer,
+        size_t stride, GLuint indices);
+    ~VAO();
+    void Bind();
+    void Unbind();
+  };
+}
+
+#endif


### PR DESCRIPTION
this wraps VAOs in a VAO object, and can emulate them when native VAOs arent available. this is necessary for OpenGL 2.0, OpenGL ES 2.0, and WebGL 1.0