### PR TITLE
fgOpenGL: check for GL errors after GetCaps

### DIFF
--- a/fgOpenGL/GLError.hpp
+++ b/fgOpenGL/GLError.hpp
@@ -36,6 +36,12 @@
     return __e.error().log(backend);            \
   }
 
+#define LOG_AND_IGNORE_ERROR(backend, ...)      \
+  if(auto __e = (__VA_ARGS__); __e.has_error()) \
+  {                                             \
+    __e.error().log(backend);                   \
+  }
+
 namespace GL {
   enum GL_Err
   {


### PR DESCRIPTION
If one of the calls in `GetCaps` failed a GL error could be left unhandled causing the next operation such as creating a buffer to mysteriously fail.

On my machine with an AMD card - which doesn't support the `*_NV` extensions used in `GetCaps` - this caused the compute test to fail as the first create buffer call would pick up the leftover error.

This feels like more of a bodge than a proper fix as it's logging the error without knowing what to do with it, so I'm leaving this as a draft.

It looks like most places use `CALLGL` to handle errors after each GL call, but `GetCaps` isn't fallible so I can't use that here without changing the interface.