### PR TITLE
flake: add flake check which runs some feather tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,16 +10,32 @@
   };
 
   outputs = { self, scopes, nixpkgs, flake-utils, nix-filter, sail-src }:
-    (flake-utils.lib.eachDefaultSystem (system:
+    # Using same set of systems as scopes.packages as we can't support systems
+    # that scopes doesn't support
+    (flake-utils.lib.eachSystem (builtins.attrNames scopes.packages) (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         selfpkgs = self.packages.${system};
+        featherNativeDevDeps = [
+          pkgs.pkg-config
+          scopes.packages.${system}.scopes
+        ];
+        featherDevDeps = [
+          backends
+          pkgs.cjson
+          selfpkgs.sail
+        ];
         devshell-ldpath =
           pkgs.lib.concatMapStringsSep ":" (lib: "${pkgs.lib.getLib lib}/lib") [
             selfpkgs.sail
             selfpkgs.fgOpenGL
             pkgs.cjson
           ];
+        # TODO: investigate something in scopes flake to automate or abstract this
+        featherDevSetupHook = ''
+          export NIX_CFLAGS_COMPILE="''${NIX_CFLAGS_COMPILE:-} $(pkg-config --cflags libcjson libsail)"
+          export LD_LIBRARY_PATH=${devshell-ldpath}:''${LD_LIBRARY_PATH:-}
+        '';
         backends = pkgs.llvmPackages_13.stdenv.mkDerivation {
           name = "backends";
           src = nix-filter.lib.filter {
@@ -45,6 +61,22 @@
           #   cp -r . $out/build-dump
           # '';
         };
+        runCommandWithFeather = name: script:
+          pkgs.runCommand name
+            {
+              nativeBuildInputs = featherNativeDevDeps;
+              buildInputs = featherDevDeps;
+            } ''
+            set -euo pipefail
+            ln -s "${./feather}" feather
+            mkdir output
+            ${featherDevSetupHook}
+            # scopes needs writable $HOME for ~/.cache/scopes
+            export HOME=$TMP
+            ${script}
+            ls output
+            mv output $out
+          '';
       in {
         packages = {
           fgOpenGL = backends;
@@ -58,15 +90,17 @@
           };
         };
         devShell = pkgs.mkShell {
-          buildInputs = [
-            scopes.packages.${system}.scopes
-            backends
-            pkgs.cjson
-            selfpkgs.sail
-          ];
+          nativeBuildInputs = featherNativeDevDeps;
+          buildInputs = featherDevDeps;
 
-          shellHook = ''
-            export LD_LIBRARY_PATH=${devshell-ldpath}:$LD_LIBRARY_PATH
+          shellHook = featherDevSetupHook;
+        };
+        checks = {
+          feather-tests = runCommandWithFeather "feather-tests" ''
+            for test in feather/{json,rendering}-test.sc; do
+              echo Running $test
+              scopes $test
+            done
           '';
         };
       })) // {

--- a/flake.nix
+++ b/flake.nix
@@ -25,12 +25,11 @@
           pkgs.cjson
           selfpkgs.sail
         ];
-        devshell-ldpath =
-          pkgs.lib.concatMapStringsSep ":" (lib: "${pkgs.lib.getLib lib}/lib") [
-            selfpkgs.sail
-            selfpkgs.fgOpenGL
-            pkgs.cjson
-          ];
+        devshell-ldpath = pkgs.lib.makeLibraryPath [
+          selfpkgs.sail
+          selfpkgs.fgOpenGL
+          pkgs.cjson
+        ];
         # TODO: investigate something in scopes flake to automate or abstract this
         featherDevSetupHook = ''
           export NIX_CFLAGS_COMPILE="''${NIX_CFLAGS_COMPILE:-} $(pkg-config --cflags libcjson libsail)"


### PR DESCRIPTION
This reuses the same setup hook for the dev shell `LD_LIBRARY_PATH` and C include path, so in theory the tests and the dev shell should break/work at the same time.

```
(env:feathergui) $ nix flake show                                                                                                                                                                      git+file:///home/lun/sync/dev/fundament/feathergui?ref=refs%2fheads%2fadd-flake-check&rev=1d777d73c6c7ba15c32868eb24912c5b063743b6
├───checks
│   ├───aarch64-linux
│   │   └───feather-tests: derivation 'feather-tests'
│   └───x86_64-linux
│       └───feather-tests: derivation 'feather-tests'
├───devShell
│   ├───aarch64-linux: development environment 'nix-shell'
│   └───x86_64-linux: development environment 'nix-shell'
└───packages
    ├───aarch64-linux
    │   ├───fgOpenGL: package 'backends'
    │   └───sail: package 'sail'
    └───x86_64-linux
        ├───fgOpenGL: package 'backends'
        └───sail: package 'sail'

(env:feathergui) $ nix flake check                                                                                                                                                                     warning: flake output attribute 'devShell' is deprecated; use 'devShells.<system>.default' instead
# no output, no errors
```

This also fixes `nix flake check` failing during eval due to trying to support systems `scopes` isn't available for, which looked like this on main:

```
(env:feathergui) $ nix flake check                                                                                                                                                                     warning: flake output attribute 'devShell' is deprecated; use 'devShells.<system>.default' instead
error: attribute 'aarch64-darwin' missing

       at /nix/store/pl2i4k1wcqgzia5g380j37p9xpnkrkqw-source/flake.nix:69:13:

           68|           buildInputs = [
           69|             scopes.packages.${system}.scopes
             |             ^
           70|             backends
(use '--show-trace' to show detailed location information)
```