### PR TITLE
Add typos protection to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Install Rust
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-          
+
     - name: Install Clang
       run: |
           export DEBIAN_FRONTEND=noninteractive
@@ -47,7 +47,7 @@ jobs:
 
     - name: Build in release mode
       run: cargo build --all --release
-      
+
     # We can't run any tests, because they would need a window manager and graphics to exist, which aren't available on standard CI
 
   fmt:
@@ -75,3 +75,14 @@ jobs:
         log-level: warn
         command: check
         arguments: --all-features
+
+  # Check for typos in the repository based on a static dictionary
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # This is pinned to a specific version because the typos dictionary can
+      # be updated between patch version, and a new dictionary can find new
+      # typos in the repo thus suddenly breaking CI unless we pin the version.
+      - uses: crate-ci/typos@v1.32.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,6 @@ jobs:
       - uses: actions/checkout@v4
 
       # This is pinned to a specific version because the typos dictionary can
-      # be updated between patch version, and a new dictionary can find new
+      # be updated between patch versions, and a new dictionary can find new
       # typos in the repo thus suddenly breaking CI unless we pin the version.
       - uses: crate-ci/typos@v1.32.0

--- a/feather-macro/src/lib.rs
+++ b/feather-macro/src/lib.rs
@@ -180,12 +180,12 @@ fn data_enum(ast: &DeriveInput) -> &DataEnum {
     if let Data::Enum(data_enum) = &ast.data {
         data_enum
     } else {
-        panic!("`Dispath` derive can only be used on an enum.");
+        panic!("`Dispatch` derive can only be used on an enum.");
     }
 }
 
 fn find_enum_module(attrs: &[syn::Attribute]) -> syn::Result<String> {
-    // Extract EnumVariantType's module, since this has to be used in conjuction with our derive
+    // Extract EnumVariantType's module, since this has to be used in conjunction with our derive
     for attr in attrs.iter() {
         if attr.path().is_ident("evt") {
             let nested = attr

--- a/feather-ui/src/component/mod.rs
+++ b/feather-ui/src/component/mod.rs
@@ -248,7 +248,7 @@ impl Root {
         event_loop: &winit::event_loop::ActiveEventLoop,
     ) -> eyre::Result<()> {
         // Initialize any states that need to be initialized before calling the layout function
-        // TODO: make this actually efficient by perfoming the initialization when a new component is initialized
+        // TODO: make this actually efficient by performing the initialization when a new component is initialized
         for (_, window) in self.children.iter() {
             let window = window.as_ref().unwrap();
             window.init_custom::<AppData, O>(manager, driver, instance, event_loop)?;

--- a/feather-ui/src/layout/leaf.rs
+++ b/feather-ui/src/layout/leaf.rs
@@ -13,7 +13,7 @@ crate::gen_from_to_dyn!(Prop);
 
 impl Prop for DRect {}
 
-// Actual leafs do not require padding, but a lot of raw elements do (text, shape, images, etc.)
+// Actual leaves do not require padding, but a lot of raw elements do (text, shape, images, etc.)
 // This inherits Prop to allow elements to "extract" the padding for the rendering system for
 // when it doesn't affect layouts.
 pub trait Padded: Prop + base::Padding {}


### PR DESCRIPTION
[`typos`](https://github.com/crate-ci/typos) CLI is a great tool. It is a typos checker with partially zero false positives because its typos dictionary is manually maintained and its main goal is to be reliable enough so that people can run it on CI. I also recommend their [vscode extension](https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode) to detect typos in IDE earlier before CI detects them.