### PR TITLE
Refactor event streams and fix other things

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
+checksum = "1e0f4f6fbdc5ee39f2ede9f5f3ec79477271a6d6a2baff22310d51736bda6cea"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "ab_glyph_rasterizer"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
+checksum = "b2187590a23ab1e3df8681afdf0987c48504d80291f002fcdb651f0ef5e25169"
 
 [[package]]
 name = "adler2"
@@ -100,9 +100,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arboard"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1df21f715862ede32a0c525ce2ca4d52626bb0007f8c18b87a384503ac33e70"
+checksum = "55f533f8e0af236ffe5eb979b99381df3258853f00ba2e44b6e1955292c75227"
 dependencies = [
  "clipboard-win",
  "image",
@@ -205,11 +205,6 @@ version = "0.1.5"
 dependencies = [
  "alicorn",
  "feather-ui",
- "im",
- "mlua",
- "ultraviolet",
- "wgpu",
- "winit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ tracing-subscriber = { version = "0.3.18", features = ["time"] }
 tracing = "0.1.40"
 feather-ui = { path = "feather-ui" }
 alicorn = "0.1.2"
-mlua = { version = "0.10", features = ["luajit52", "vendored"] }
 feather-macro = { version = "0.1", path = "feather-macro" }
 cosmic-text = { git = "https://github.com/pop-os/cosmic-text" }  # TODO: change back to a proper release once fixes we need make it into stable
 

--- a/deny.toml
+++ b/deny.toml
@@ -45,4 +45,4 @@ skip-tree = []
 unknown-registry = "warn"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/pop-os/cosmic-text"]

--- a/examples/basic-alc/Cargo.toml
+++ b/examples/basic-alc/Cargo.toml
@@ -19,10 +19,5 @@ name = "basic-alc"
 path = "main.rs"
 
 [dependencies]
-wgpu.workspace = true
-winit.workspace = true
 feather-ui.workspace = true
-ultraviolet.workspace = true
-im.workspace = true
 alicorn.workspace = true
-mlua.workspace = true

--- a/examples/basic-alc/main.rs
+++ b/examples/basic-alc/main.rs
@@ -3,8 +3,9 @@
 
 use feather_ui::App;
 use feather_ui::lua::{AppState, LuaApp};
-use mlua::Function;
-use mlua::prelude::*;
+use feather_ui::mlua::Function;
+use feather_ui::mlua::prelude::*;
+use feather_ui::winit::event_loop;
 
 fn wrap_luafunc(
     f: Function,
@@ -31,8 +32,8 @@ fn main() {
 
         let onclick = Box::new(wrap_luafunc(onclick));
         let outline = LuaApp { window, init };
-        let (mut app, event_loop): (App<AppState, LuaApp>, winit::event_loop::EventLoop<()>) =
-            App::new(LuaValue::Integer(0), vec![onclick], outline).unwrap();
+        let (mut app, event_loop): (App<AppState, LuaApp>, event_loop::EventLoop<()>) =
+            App::new(LuaValue::Integer(0), vec![onclick], outline, |_| ()).unwrap();
 
         event_loop.run_app(&mut app).unwrap();
     }

--- a/examples/basic-rs/main.rs
+++ b/examples/basic-rs/main.rs
@@ -49,7 +49,7 @@ impl FnPersist<CounterState, im::HashMap<Rc<SourceID>, Option<Window>>> for Basi
         (CounterState { count: -1 }, im::HashMap::new())
     }
     fn call(
-        &self,
+        &mut self,
         mut store: Self::Store,
         args: &CounterState,
     ) -> (Self::Store, im::HashMap<Rc<SourceID>, Option<Window>>) {

--- a/examples/calculator-rs/build.rs
+++ b/examples/calculator-rs/build.rs
@@ -62,9 +62,6 @@ fn main() {
         }
         // We do not panic on error here so systems without dotnet can still build the rust example
         Ok(false) => print!("dotnet build failed, calculator-cs will not be available."),
-        Err(e) => print!(
-            "Error running dotnet build, calculator-cs will not be available: {}",
-            e
-        ),
+        Err(e) => print!("Error running dotnet build, calculator-cs will not be available: {e}"),
     }
 }

--- a/examples/calculator-rs/src/lib.rs
+++ b/examples/calculator-rs/src/lib.rs
@@ -11,10 +11,9 @@ use feather_ui::component::window::Window;
 use feather_ui::component::{mouse_area, ComponentFrom};
 use feather_ui::layout::fixed;
 use feather_ui::persist::FnPersist;
-use feather_ui::ultraviolet::{Vec2, Vec4};
+use feather_ui::ultraviolet::Vec4;
 use feather_ui::{
-    gen_id, im, AbsRect, App, DRect, DataID, RelRect, Slot, SourceID, WrapEventEx, FILL_DRECT,
-    ZERO_RECT,
+    gen_id, im, AbsRect, App, DRect, RelRect, Slot, SourceID, WrapEventEx, FILL_DRECT, ZERO_RECT,
 };
 use std::any::{Any, TypeId};
 use std::f32;
@@ -171,7 +170,7 @@ impl FnPersist<CalcFFI, im::HashMap<Rc<SourceID>, Option<Window>>> for CalcApp {
         (CalcFFI(self.init_calc.clone()), im::HashMap::new())
     }
     fn call(
-        &self,
+        &mut self,
         mut store: Self::Store,
         args: &CalcFFI,
     ) -> (Self::Store, im::HashMap<Rc<SourceID>, Option<Window>>) {
@@ -179,13 +178,9 @@ impl FnPersist<CalcFFI, im::HashMap<Rc<SourceID>, Option<Window>>> for CalcApp {
         let mut children: im::Vector<Option<Box<ComponentFrom<dyn fixed::Prop>>>> =
             im::Vector::new();
 
-        let button_id = gen_id!();
-
         for (i, (txt, _, color)) in BUTTONS.iter().enumerate() {
-            let idx_id = gen_id!(button_id).child(DataID::Int(i as i64));
-
             let rect = Shape::<DRect, { ShapeKind::RoundRect as u8 }>::new(
-                gen_id!(idx_id),
+                gen_id!(),
                 FILL_DRECT.into(),
                 0.0,
                 0.0,
@@ -195,7 +190,7 @@ impl FnPersist<CalcFFI, im::HashMap<Rc<SourceID>, Option<Window>>> for CalcApp {
             );
 
             let text = Text::<DRect> {
-                id: gen_id!(idx_id),
+                id: gen_id!(),
                 props: FILL_DRECT.into(),
                 text: txt.to_string(),
                 font_size: 40.0,
@@ -213,7 +208,7 @@ impl FnPersist<CalcFFI, im::HashMap<Rc<SourceID>, Option<Window>>> for CalcApp {
             let (w, h) = (1.0 / ROW_COUNT as f32, 1.0 / 7.0);
 
             let btn = Button::<FixedData>::new(
-                gen_id!(idx_id),
+                gen_id!(gen_id!(), i),
                 FixedData {
                     area: feather_ui::URect {
                         abs: AbsRect::new(4.0, 4.0, -4.0, -4.0),
@@ -236,7 +231,7 @@ impl FnPersist<CalcFFI, im::HashMap<Rc<SourceID>, Option<Window>>> for CalcApp {
         }
 
         let display = Text::<DRect> {
-            id: gen_id!(button_id),
+            id: gen_id!(),
             props: FILL_DRECT.into(),
             text: args.0.get().to_string(),
             font_size: 60.0,
@@ -245,7 +240,7 @@ impl FnPersist<CalcFFI, im::HashMap<Rc<SourceID>, Option<Window>>> for CalcApp {
         };
 
         let text_bg = Shape::<DRect, { ShapeKind::RoundRect as u8 }>::new(
-            gen_id!(button_id),
+            gen_id!(),
             Rc::new(DRect {
                 px: ZERO_RECT,
                 dp: ZERO_RECT,

--- a/examples/graph-rs/main.rs
+++ b/examples/graph-rs/main.rs
@@ -64,7 +64,7 @@ impl FnPersist<GraphState, im::HashMap<Rc<SourceID>, Option<Window>>> for BasicA
         )
     }
     fn call(
-        &self,
+        &mut self,
         mut store: Self::Store,
         args: &GraphState,
     ) -> (Self::Store, im::HashMap<Rc<SourceID>, Option<Window>>) {

--- a/examples/grid-rs/main.rs
+++ b/examples/grid-rs/main.rs
@@ -108,7 +108,7 @@ impl FnPersist<CounterState, im::HashMap<Rc<SourceID>, Option<Window>>> for Basi
         (CounterState { count: 99999999 }, im::HashMap::new())
     }
     fn call(
-        &self,
+        &mut self,
         mut store: Self::Store,
         args: &CounterState,
     ) -> (Self::Store, im::HashMap<Rc<SourceID>, Option<Window>>) {

--- a/examples/list-rs/main.rs
+++ b/examples/list-rs/main.rs
@@ -123,7 +123,7 @@ impl FnPersist<CounterState, im::HashMap<Rc<SourceID>, Option<Window>>> for Basi
         (CounterState { count: -1 }, im::HashMap::new())
     }
     fn call(
-        &self,
+        &mut self,
         mut store: Self::Store,
         args: &CounterState,
     ) -> (Self::Store, im::HashMap<Rc<SourceID>, Option<Window>>) {

--- a/examples/paragraph-rs/main.rs
+++ b/examples/paragraph-rs/main.rs
@@ -105,7 +105,7 @@ impl FnPersist<Blocker, im::HashMap<Rc<SourceID>, Option<Window>>> for BasicApp 
         )
     }
     fn call(
-        &self,
+        &mut self,
         mut store: Self::Store,
         args: &Blocker,
     ) -> (Self::Store, im::HashMap<Rc<SourceID>, Option<Window>>) {

--- a/examples/textbox-rs/main.rs
+++ b/examples/textbox-rs/main.rs
@@ -66,7 +66,7 @@ impl FnPersist<TextState, im::HashMap<Rc<SourceID>, Option<Window>>> for BasicAp
         )
     }
     fn call(
-        &self,
+        &mut self,
         mut store: Self::Store,
         args: &TextState,
     ) -> (Self::Store, im::HashMap<Rc<SourceID>, Option<Window>>) {

--- a/feather-ui/Cargo.toml
+++ b/feather-ui/Cargo.toml
@@ -20,6 +20,10 @@ license.workspace = true
 path = "src/lib.rs"
 doctest = false
 
+[features]
+default = ["lua"]
+lua = ["dep:mlua"]
+
 [dependencies]
 im.workspace = true
 wgpu.workspace = true
@@ -30,7 +34,10 @@ tracing-subscriber.workspace = true
 ultraviolet.workspace = true
 dyn-clone = "1.0"
 derive-where = "1.2.7"
-mlua.workspace = true
+mlua = { version = "0.10", features = [
+  "luajit52",
+  "vendored",
+], optional = true }
 enum_variant_type = "0.3.1"
 smallvec = { version = "1.13", features = ["union", "const_generics"] }
 thiserror = "2.0"

--- a/feather-ui/src/component/button.rs
+++ b/feather-ui/src/component/button.rs
@@ -66,21 +66,18 @@ where
 {
     fn layout(
         &self,
-        state: &crate::StateManager,
+        state: &mut crate::StateManager,
         driver: &crate::graphics::Driver,
         window: &Rc<SourceID>,
-        config: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn Layout<T>> {
-        let map = VectorMap::new(
+        let mut map = VectorMap::new(
             |child: &Option<Box<ComponentFrom<dyn fixed::Prop>>>| -> Option<Box<dyn Layout<<dyn fixed::Prop as Desc>::Child>>> {
-                Some(child.as_ref().unwrap().layout(state, driver, window,config))
+                Some(child.as_ref().unwrap().layout(state, driver, window))
             },
         );
 
         let (_, mut children) = map.call(Default::default(), &self.children);
-        children.push_back(Some(Box::new(
-            self.marea.layout(state, driver, window, config),
-        )));
+        children.push_back(Some(Box::new(self.marea.layout(state, driver, window))));
 
         Box::new(layout::Node::<T, dyn fixed::Prop> {
             props: self.props.clone(),

--- a/feather-ui/src/component/domain_line.rs
+++ b/feather-ui/src/component/domain_line.rs
@@ -25,10 +25,9 @@ where
 {
     fn layout(
         &self,
-        _: &crate::StateManager,
+        _: &mut crate::StateManager,
         _: &crate::graphics::Driver,
-        _window: &Rc<SourceID>,
-        _: &wgpu::SurfaceConfiguration,
+        _: &Rc<SourceID>,
     ) -> Box<dyn Layout<T>> {
         Box::new(layout::Node::<T, dyn base::Empty> {
             props: self.props.clone(),

--- a/feather-ui/src/component/domain_point.rs
+++ b/feather-ui/src/component/domain_point.rs
@@ -29,10 +29,9 @@ where
 {
     fn layout(
         &self,
-        _: &crate::StateManager,
+        _: &mut crate::StateManager,
         _: &crate::graphics::Driver,
         _: &Rc<SourceID>,
-        _: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn crate::layout::Layout<T>> {
         Box::new(crate::layout::Node::<T, dyn domain_write::Prop> {
             props: self.props.clone(),

--- a/feather-ui/src/component/flexbox.rs
+++ b/feather-ui/src/component/flexbox.rs
@@ -34,14 +34,13 @@ impl<T: flex::Prop + 'static> FlexBox<T> {
 impl<T: flex::Prop + 'static> super::Component<T> for FlexBox<T> {
     fn layout(
         &self,
-        state: &crate::StateManager,
+        state: &mut crate::StateManager,
         driver: &crate::graphics::Driver,
         window: &Rc<SourceID>,
-        config: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn Layout<T>> {
-        let map = VectorMap::new(
+        let mut map = VectorMap::new(
             |child: &Option<Box<ComponentFrom<dyn flex::Prop>>>| -> Option<Box<dyn Layout<<dyn flex::Prop as Desc>::Child>>> {
-                Some(child.as_ref().unwrap().layout(state, driver,window, config))
+                Some(child.as_ref().unwrap().layout(state, driver,window))
             },
         );
 

--- a/feather-ui/src/component/gridbox.rs
+++ b/feather-ui/src/component/gridbox.rs
@@ -34,14 +34,13 @@ impl<T: grid::Prop + 'static> GridBox<T> {
 impl<T: grid::Prop + 'static> super::Component<T> for GridBox<T> {
     fn layout(
         &self,
-        state: &crate::StateManager,
+        state: &mut crate::StateManager,
         driver: &crate::graphics::Driver,
         window: &Rc<SourceID>,
-        config: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn Layout<T>> {
-        let map = VectorMap::new(
+        let mut map = VectorMap::new(
             |child: &Option<Box<ComponentFrom<dyn grid::Prop>>>| -> Option<Box<dyn Layout<<dyn grid::Prop as Desc>::Child>>> {
-                Some(child.as_ref().unwrap().layout(state, driver,window, config))
+                Some(child.as_ref().unwrap().layout(state, driver,window))
             },
         );
 

--- a/feather-ui/src/component/line.rs
+++ b/feather-ui/src/component/line.rs
@@ -25,10 +25,9 @@ where
 {
     fn layout(
         &self,
-        _: &crate::StateManager,
+        _: &mut crate::StateManager,
         _: &crate::graphics::Driver,
         _window: &Rc<SourceID>,
-        _: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn Layout<T>> {
         Box::new(layout::Node::<T, dyn base::Empty> {
             props: self.props.clone(),

--- a/feather-ui/src/component/listbox.rs
+++ b/feather-ui/src/component/listbox.rs
@@ -34,14 +34,13 @@ impl<T: list::Prop + 'static> ListBox<T> {
 impl<T: list::Prop + 'static> super::Component<T> for ListBox<T> {
     fn layout(
         &self,
-        state: &crate::StateManager,
+        state: &mut crate::StateManager,
         driver: &crate::graphics::Driver,
         window: &Rc<SourceID>,
-        config: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn Layout<T>> {
-        let map = VectorMap::new(
+        let mut map = VectorMap::new(
             |child: &Option<Box<ComponentFrom<dyn list::Prop>>>| -> Option<Box<dyn Layout<<dyn list::Prop as Desc>::Child>>> {
-                Some(child.as_ref().unwrap().layout(state, driver,window, config))
+                Some(child.as_ref().unwrap().layout(state, driver,window))
             },
         );
 

--- a/feather-ui/src/component/mouse_area.rs
+++ b/feather-ui/src/component/mouse_area.rs
@@ -6,9 +6,11 @@ use crate::component::Layout;
 use crate::input::{MouseButton, MouseState, RawEvent, RawEventKind};
 use crate::layout::leaf;
 use crate::{Dispatchable, Slot, SourceID, layout};
+use core::f32;
 use derive_where::derive_where;
 use enum_variant_type::EnumVariantType;
 use feather_macro::Dispatch;
+use smallvec::SmallVec;
 use std::collections::HashMap;
 use std::rc::Rc;
 use ultraviolet::Vec2;
@@ -30,6 +32,213 @@ pub enum MouseAreaEvent {
 struct MouseAreaState {
     lastdown: HashMap<(DeviceId, u64), (Vec2, bool)>,
     hover: bool,
+    deadzone: f32,
+}
+impl MouseAreaState {
+    fn hover_event(buttons: u16, hover: bool) -> MouseAreaEvent {
+        let active = (buttons & MouseButton::Left as u16) != 0;
+        match (active, hover) {
+            (true, true) => MouseAreaEvent::Active,
+            (true, false) => MouseAreaEvent::Hover,
+            (false, true) => MouseAreaEvent::Hover,
+            (false, false) => MouseAreaEvent::Default,
+        }
+    }
+}
+
+impl super::EventStream for MouseAreaState {
+    type Input = RawEvent;
+    type Output = MouseAreaEvent;
+
+    fn process(
+        mut self,
+        input: Self::Input,
+        area: crate::AbsRect,
+        dpi: crate::Vec2,
+        _: &std::sync::Weak<crate::Driver>,
+    ) -> eyre::Result<
+        (Self, smallvec::SmallVec<[Self::Output; 1]>),
+        (Self, smallvec::SmallVec<[Self::Output; 1]>),
+    > {
+        match input {
+            RawEvent::Key {
+                down,
+                logical_key: winit::keyboard::Key::Named(code),
+                ..
+            } => {
+                if (code == NamedKey::Enter || code == NamedKey::Accept) && down {
+                    return Ok((
+                        self,
+                        [MouseAreaEvent::OnClick(
+                            crate::input::MouseButton::Left,
+                            Vec2::zero(),
+                        )]
+                        .into(),
+                    ));
+                }
+            }
+            RawEvent::MouseOn { all_buttons, .. } | RawEvent::MouseOff { all_buttons, .. } => {
+                self.hover = matches!(input, RawEvent::MouseOff { .. });
+                let hover = Self::hover_event(all_buttons, self.hover);
+                return Ok((self, [hover].into()));
+            }
+            RawEvent::MouseMove {
+                device_id,
+                pos,
+                all_buttons,
+                ..
+            } => {
+                let hover = Self::hover_event(all_buttons, self.hover);
+                let pos = crate::graphics::pixel_to_vec(pos);
+                for i in 0..5 {
+                    if let Some((last_pos, drag)) = self.lastdown.get_mut(&(device_id, (1 << i))) {
+                        let diff = pos - *last_pos;
+                        if !*drag && diff.dot(diff) > self.deadzone {
+                            *drag = true;
+                        }
+
+                        let b = match i {
+                            0 => MouseButton::Left,
+                            1 => MouseButton::Middle,
+                            2 => MouseButton::Right,
+                            3 => MouseButton::Back,
+                            4 => MouseButton::Forward,
+                            _ => panic!("Impossible number"),
+                        };
+                        if *drag {
+                            *last_pos = pos;
+                            return Ok((
+                                self,
+                                SmallVec::from_iter([hover, MouseAreaEvent::OnDrag(b, diff / dpi)]),
+                            ));
+                        }
+                    }
+                }
+
+                return Ok((self, [hover].into()));
+            }
+            RawEvent::Mouse {
+                device_id,
+                state,
+                pos,
+                button,
+                ..
+            } => {
+                let pos = crate::graphics::pixel_to_vec(pos);
+                let hover = Self::hover_event(button as u16, self.hover);
+                match state {
+                    MouseState::Down => {
+                        if area.contains(pos) {
+                            self.lastdown
+                                .insert((device_id, button as u64), (pos, false));
+                            return Ok((self, [hover].into()));
+                        }
+                    }
+                    MouseState::Up => {
+                        if let Some((last_pos, drag)) =
+                            self.lastdown.remove(&(device_id, button as u64))
+                        {
+                            if area.contains(pos) {
+                                return Ok((
+                                    self,
+                                    SmallVec::from_iter([
+                                        if drag {
+                                            let diff = pos - last_pos;
+                                            MouseAreaEvent::OnDrag(button, diff / dpi)
+                                        } else {
+                                            MouseAreaEvent::OnClick(button, pos / dpi)
+                                        },
+                                        hover,
+                                    ]),
+                                ));
+                            }
+                        }
+                    }
+                    MouseState::DblClick => {
+                        if let Some((last_pos, drag)) =
+                            self.lastdown.remove(&(device_id, button as u64))
+                        {
+                            if area.contains(pos) {
+                                return Ok((
+                                    self,
+                                    if drag {
+                                        SmallVec::from_iter([
+                                            MouseAreaEvent::OnClick(button, pos / dpi),
+                                            MouseAreaEvent::OnDblClick(button, pos / dpi),
+                                            hover,
+                                        ])
+                                    } else {
+                                        SmallVec::from_iter([
+                                            if drag {
+                                                let diff = pos - last_pos;
+                                                MouseAreaEvent::OnDrag(button, diff / dpi)
+                                            } else {
+                                                MouseAreaEvent::OnClick(button, pos / dpi)
+                                            },
+                                            hover,
+                                        ])
+                                    },
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+            RawEvent::Touch {
+                device_id,
+                index,
+                state,
+                pos,
+                ..
+            } => match state {
+                crate::input::TouchState::Start => {
+                    let hover = Self::hover_event(MouseButton::Left as u16, self.hover);
+                    if area.contains(pos.xy()) {
+                        self.lastdown.insert((device_id, index), (pos.xy(), false));
+                        return Ok((self, [hover].into()));
+                    }
+                }
+                crate::input::TouchState::Move => {
+                    let hover = Self::hover_event(MouseButton::Left as u16, self.hover);
+                    if let Some((last_pos, drag)) = self.lastdown.get_mut(&(device_id, index)) {
+                        let diff = pos.xy() - *last_pos;
+                        if !*drag && diff.dot(diff) > self.deadzone {
+                            *drag = true;
+                        }
+                        if *drag {
+                            return Ok((
+                                self,
+                                SmallVec::from_iter([
+                                    hover,
+                                    MouseAreaEvent::OnDrag(MouseButton::Left, diff / dpi),
+                                ]),
+                            ));
+                        }
+                    }
+                }
+                crate::input::TouchState::End => {
+                    let hover = Self::hover_event(0, self.hover);
+                    if let Some((_, drag)) = self.lastdown.remove(&(device_id, index)) {
+                        if area.contains(pos.xy()) {
+                            return Ok((
+                                self,
+                                SmallVec::from_iter([
+                                    if drag {
+                                        MouseAreaEvent::OnDrag(MouseButton::Left, pos.xy() / dpi)
+                                    } else {
+                                        MouseAreaEvent::OnClick(MouseButton::Left, pos.xy() / dpi)
+                                    },
+                                    hover,
+                                ]),
+                            ));
+                        }
+                    }
+                }
+            },
+            _ => (),
+        }
+        Err((self, SmallVec::new()))
+    }
 }
 
 #[derive_where(Clone)]
@@ -54,16 +263,6 @@ impl<T: leaf::Prop + 'static> MouseArea<T> {
             slots,
         }
     }
-
-    fn hover_event(buttons: u16, hover: bool) -> MouseAreaEvent {
-        let active = (buttons & MouseButton::Left as u16) != 0;
-        match (active, hover) {
-            (true, true) => MouseAreaEvent::Active,
-            (true, false) => MouseAreaEvent::Hover,
-            (false, true) => MouseAreaEvent::Hover,
-            (false, false) => MouseAreaEvent::Default,
-        }
-    }
 }
 
 impl<T: leaf::Prop + 'static> crate::StateMachineChild for MouseArea<T> {
@@ -74,225 +273,18 @@ impl<T: leaf::Prop + 'static> crate::StateMachineChild for MouseArea<T> {
         &self,
         _: &std::sync::Weak<crate::Driver>,
     ) -> Result<Box<dyn super::StateMachineWrapper>, crate::Error> {
-        let deadzone = self.deadzone;
-        let oninput = Box::new(
-            crate::wrap_event::<RawEvent, MouseAreaEvent, MouseAreaState>(
-                move |e, area, dpi, mut data| {
-                    match e {
-                        RawEvent::Key {
-                            down,
-                            logical_key: winit::keyboard::Key::Named(code),
-                            ..
-                        } => {
-                            if (code == NamedKey::Enter || code == NamedKey::Accept) && down {
-                                return Ok((
-                                    data,
-                                    vec![MouseAreaEvent::OnClick(
-                                        crate::input::MouseButton::Left,
-                                        Vec2::zero(),
-                                    )],
-                                ));
-                            }
-                        }
-                        RawEvent::MouseOn { all_buttons, .. }
-                        | RawEvent::MouseOff { all_buttons, .. } => {
-                            data.hover = matches!(e, RawEvent::MouseOff { .. });
-                            let hover = Self::hover_event(all_buttons, data.hover);
-                            return Ok((data, vec![hover]));
-                        }
-                        RawEvent::MouseMove {
-                            device_id,
-                            pos,
-                            all_buttons,
-                            ..
-                        } => {
-                            let hover = Self::hover_event(all_buttons, data.hover);
-                            let pos = crate::graphics::pixel_to_vec(pos);
-                            for i in 0..5 {
-                                if let Some((last_pos, drag)) =
-                                    data.lastdown.get_mut(&(device_id, (1 << i)))
-                                {
-                                    let diff = pos - *last_pos;
-                                    if !*drag && diff.dot(diff) > deadzone {
-                                        *drag = true;
-                                    }
-
-                                    let b = match i {
-                                        0 => MouseButton::Left,
-                                        1 => MouseButton::Middle,
-                                        2 => MouseButton::Right,
-                                        3 => MouseButton::Back,
-                                        4 => MouseButton::Forward,
-                                        _ => panic!("Impossible number"),
-                                    };
-                                    if *drag {
-                                        *last_pos = pos;
-                                        return Ok((
-                                            data,
-                                            vec![hover, MouseAreaEvent::OnDrag(b, diff / dpi)],
-                                        ));
-                                    }
-                                }
-                            }
-
-                            return Ok((data, vec![hover]));
-                        }
-                        RawEvent::Mouse {
-                            device_id,
-                            state,
-                            pos,
-                            button,
-                            ..
-                        } => {
-                            let pos = crate::graphics::pixel_to_vec(pos);
-                            let hover = Self::hover_event(button as u16, data.hover);
-                            match state {
-                                MouseState::Down => {
-                                    if area.contains(pos) {
-                                        data.lastdown
-                                            .insert((device_id, button as u64), (pos, false));
-                                        return Ok((data, vec![hover]));
-                                    }
-                                }
-                                MouseState::Up => {
-                                    if let Some((last_pos, drag)) =
-                                        data.lastdown.remove(&(device_id, button as u64))
-                                    {
-                                        if area.contains(pos) {
-                                            return Ok((
-                                                data,
-                                                vec![
-                                                    if drag {
-                                                        let diff = pos - last_pos;
-                                                        MouseAreaEvent::OnDrag(button, diff / dpi)
-                                                    } else {
-                                                        MouseAreaEvent::OnClick(button, pos / dpi)
-                                                    },
-                                                    hover,
-                                                ],
-                                            ));
-                                        }
-                                    }
-                                }
-                                MouseState::DblClick => {
-                                    if let Some((last_pos, drag)) =
-                                        data.lastdown.remove(&(device_id, button as u64))
-                                    {
-                                        if area.contains(pos) {
-                                            return Ok((
-                                                data,
-                                                if drag {
-                                                    vec![
-                                                        MouseAreaEvent::OnClick(button, pos / dpi),
-                                                        MouseAreaEvent::OnDblClick(
-                                                            button,
-                                                            pos / dpi,
-                                                        ),
-                                                        hover,
-                                                    ]
-                                                } else {
-                                                    vec![
-                                                        if drag {
-                                                            let diff = pos - last_pos;
-                                                            MouseAreaEvent::OnDrag(
-                                                                button,
-                                                                diff / dpi,
-                                                            )
-                                                        } else {
-                                                            MouseAreaEvent::OnClick(
-                                                                button,
-                                                                pos / dpi,
-                                                            )
-                                                        },
-                                                        hover,
-                                                    ]
-                                                },
-                                            ));
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        RawEvent::Touch {
-                            device_id,
-                            index,
-                            state,
-                            pos,
-                            ..
-                        } => match state {
-                            crate::input::TouchState::Start => {
-                                let hover = Self::hover_event(MouseButton::Left as u16, data.hover);
-                                if area.contains(pos.xy()) {
-                                    data.lastdown.insert((device_id, index), (pos.xy(), false));
-                                    return Ok((data, vec![hover]));
-                                }
-                            }
-                            crate::input::TouchState::Move => {
-                                let hover = Self::hover_event(MouseButton::Left as u16, data.hover);
-                                if let Some((last_pos, drag)) =
-                                    data.lastdown.get_mut(&(device_id, index))
-                                {
-                                    let diff = pos.xy() - *last_pos;
-                                    if !*drag && diff.dot(diff) > deadzone {
-                                        *drag = true;
-                                    }
-                                    if *drag {
-                                        return Ok((
-                                            data,
-                                            vec![
-                                                hover,
-                                                MouseAreaEvent::OnDrag(
-                                                    MouseButton::Left,
-                                                    diff / dpi,
-                                                ),
-                                            ],
-                                        ));
-                                    }
-                                }
-                            }
-                            crate::input::TouchState::End => {
-                                let hover = Self::hover_event(0, data.hover);
-                                if let Some((_, drag)) = data.lastdown.remove(&(device_id, index)) {
-                                    if area.contains(pos.xy()) {
-                                        return Ok((
-                                            data,
-                                            vec![
-                                                if drag {
-                                                    MouseAreaEvent::OnDrag(
-                                                        MouseButton::Left,
-                                                        pos.xy() / dpi,
-                                                    )
-                                                } else {
-                                                    MouseAreaEvent::OnClick(
-                                                        MouseButton::Left,
-                                                        pos.xy() / dpi,
-                                                    )
-                                                },
-                                                hover,
-                                            ],
-                                        ));
-                                    }
-                                }
-                            }
-                        },
-                        _ => (),
-                    }
-                    Err((data, vec![]))
-                },
-            ),
-        );
-
-        //<MouseAreaEvent, MouseAreaState, 1, 3>
         Ok(Box::new(StateMachine {
-            state: Some(Default::default()),
-            input: [(
-                RawEventKind::Mouse as u64
-                    | RawEventKind::MouseMove as u64
-                    | RawEventKind::Touch as u64
-                    | RawEventKind::Key as u64,
-                oninput,
-            )],
+            state: Some(MouseAreaState {
+                lastdown: HashMap::new(),
+                hover: false,
+                deadzone: f32::INFINITY,
+            }),
+            input_mask: RawEventKind::Mouse as u64
+                | RawEventKind::MouseMove as u64
+                | RawEventKind::Touch as u64
+                | RawEventKind::Key as u64,
             output: self.slots.clone(),
+            changed: true,
         }))
     }
 }
@@ -303,11 +295,23 @@ where
 {
     fn layout(
         &self,
-        _: &crate::StateManager,
+        manager: &mut crate::StateManager,
         _: &crate::graphics::Driver,
         _: &Rc<SourceID>,
-        _: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn Layout<T> + 'static> {
+        manager
+            .get_mut::<StateMachine<MouseAreaState, { MouseAreaEvent::SIZE }>>(&self.id)
+            .and_then(|state| {
+                state
+                    .state
+                    .as_mut()
+                    .ok_or(crate::Error::InternalFailure.into())
+            })
+            .map(|state| {
+                state.deadzone = self.deadzone;
+            })
+            .unwrap();
+
         Box::new(layout::Node::<T, dyn leaf::Prop> {
             props: self.props.clone(),
             children: Default::default(),

--- a/feather-ui/src/component/paragraph.rs
+++ b/feather-ui/src/component/paragraph.rs
@@ -113,14 +113,13 @@ impl<T: flex::Prop + 'static> Paragraph<T> {
 impl<T: flex::Prop + 'static> super::Component<T> for Paragraph<T> {
     fn layout(
         &self,
-        state: &crate::StateManager,
+        state: &mut crate::StateManager,
         driver: &crate::graphics::Driver,
         window: &Rc<SourceID>,
-        config: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn Layout<T>> {
-        let map = VectorMap::new(
+        let mut map = VectorMap::new(
             |child: &Option<Box<ComponentFrom<dyn flex::Prop>>>| -> Option<Box<dyn Layout<<dyn flex::Prop as Desc>::Child>>> {
-                Some(child.as_ref().unwrap().layout(state, driver, window, config))
+                Some(child.as_ref().unwrap().layout(state, driver, window))
             },
         );
 

--- a/feather-ui/src/component/region.rs
+++ b/feather-ui/src/component/region.rs
@@ -36,14 +36,13 @@ where
 {
     fn layout(
         &self,
-        state: &crate::StateManager,
+        state: &mut crate::StateManager,
         driver: &crate::graphics::Driver,
         window: &Rc<SourceID>,
-        config: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn Layout<T>> {
-        let map = VectorMap::new(
+        let mut map = VectorMap::new(
             |child: &Option<Box<ComponentFrom<dyn fixed::Prop>>>| -> Option<Box<dyn Layout<<dyn fixed::Prop as Desc>::Child>>> {
-                Some(child.as_ref().unwrap().layout(state, driver, window, config))
+                Some(child.as_ref().unwrap().layout(state, driver, window))
             },
         );
 

--- a/feather-ui/src/component/shape.rs
+++ b/feather-ui/src/component/shape.rs
@@ -26,6 +26,87 @@ pub struct Shape<T: leaf::Padded + 'static, const KIND: u8> {
     pub outline: sRGB,
 }
 
+pub fn round_rect<T: leaf::Padded + 'static>(
+    id: std::rc::Rc<SourceID>,
+    props: Rc<T>,
+    border: f32,
+    blur: f32,
+    corners: Vec4,
+    fill: sRGB,
+    outline: sRGB,
+) -> Shape<T, { ShapeKind::RoundRect as u8 }> {
+    Shape {
+        id,
+        props,
+        border,
+        blur,
+        corners,
+        fill,
+        outline,
+    }
+}
+
+pub fn triangle<T: leaf::Padded + 'static>(
+    id: std::rc::Rc<SourceID>,
+    props: Rc<T>,
+    border: f32,
+    blur: f32,
+    corners: ultraviolet::Vec3,
+    offset: f32,
+    fill: sRGB,
+    outline: sRGB,
+) -> Shape<T, { ShapeKind::Triangle as u8 }> {
+    Shape {
+        id,
+        props,
+        border,
+        blur,
+        corners: Vec4::new(corners.x, corners.y, corners.z, offset),
+        fill,
+        outline,
+    }
+}
+
+pub fn circle<T: leaf::Padded + 'static>(
+    id: std::rc::Rc<SourceID>,
+    props: Rc<T>,
+    border: f32,
+    blur: f32,
+    radii: Vec2,
+    fill: sRGB,
+    outline: sRGB,
+) -> Shape<T, { ShapeKind::Circle as u8 }> {
+    Shape {
+        id,
+        props,
+        border,
+        blur,
+        corners: Vec4::new(radii.x, radii.y, 0.0, 0.0),
+        fill,
+        outline,
+    }
+}
+
+pub fn arcs<T: leaf::Padded + 'static>(
+    id: std::rc::Rc<SourceID>,
+    props: Rc<T>,
+    border: f32,
+    blur: f32,
+    arcs: Vec4,
+    fill: sRGB,
+    outline: sRGB,
+) -> Shape<T, { ShapeKind::Arc as u8 }> {
+    Shape {
+        id,
+        props,
+        border,
+        blur,
+        corners: arcs,
+        fill,
+        outline,
+    }
+}
+
 impl<T: leaf::Padded + 'static, const KIND: u8> Clone for Shape<T, KIND> {
     fn clone(&self) -> Self {
         Self {
@@ -62,7 +143,7 @@ impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::RoundRect as u8 }> {
     }
 }
 
-impl<T: leaf::Padded + 'static> Shape<T, 1> {
+impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::Triangle as u8 }> {
     pub fn new(
         id: std::rc::Rc<SourceID>,
         props: Rc<T>,
@@ -85,7 +166,7 @@ impl<T: leaf::Padded + 'static> Shape<T, 1> {
     }
 }
 
-impl<T: leaf::Padded + 'static> Shape<T, 2> {
+impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::Circle as u8 }> {
     pub fn new(
         id: std::rc::Rc<SourceID>,
         props: Rc<T>,
@@ -107,7 +188,7 @@ impl<T: leaf::Padded + 'static> Shape<T, 2> {
     }
 }
 
-impl<T: leaf::Padded + 'static> Shape<T, 3> {
+impl<T: leaf::Padded + 'static> Shape<T, { ShapeKind::Arc as u8 }> {
     pub fn new(
         id: std::rc::Rc<SourceID>,
         props: Rc<T>,
@@ -141,10 +222,9 @@ where
 {
     fn layout(
         &self,
-        state: &crate::StateManager,
+        state: &mut crate::StateManager,
         _: &crate::graphics::Driver,
         window: &Rc<SourceID>,
-        _: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn Layout<T>> {
         let winstate: &WindowStateMachine = state.get(window).unwrap();
         let dpi = winstate.state.as_ref().map(|x| x.dpi).unwrap_or(BASE_DPI);

--- a/feather-ui/src/component/textbox.rs
+++ b/feather-ui/src/component/textbox.rs
@@ -6,9 +6,9 @@ use crate::color::sRGB;
 use crate::editor::Editor;
 use crate::input::{ModifierKeys, MouseButton, MouseState, RawEvent, RawEventKind};
 use crate::layout::{Layout, base, leaf};
-use crate::text::Change;
-use crate::{Error, SourceID, WindowStateMachine, layout};
-use cosmic_text::{Action, Cursor};
+use crate::text::{Change, EditBuffer};
+use crate::{Dispatchable, Error, SourceID, WindowStateMachine, layout};
+use cosmic_text::{Action, Buffer, Cursor};
 use derive_where::derive_where;
 use enum_variant_type::EnumVariantType;
 use feather_macro::Dispatch;
@@ -32,6 +32,417 @@ struct TextBoxState {
     cursor_count: AtomicUsize,
     focused: bool,
     editor: Editor,
+    props: Rc<dyn Prop + 'static>,
+}
+
+impl TextBoxState {
+    fn translate(e: RawEvent) -> RawEvent {
+        match e {
+            RawEvent::Key {
+                device_id,
+                physical_key: PhysicalKey::Code(key),
+                location,
+                down,
+                logical_key,
+                modifiers,
+            } => {
+                let k = match (key, down, modifiers & ModifierKeys::Control as u8 != 0) {
+                    (KeyCode::KeyA, true, true) => Key::Named(NamedKey::Select),
+                    (KeyCode::KeyC, true, true) => Key::Named(NamedKey::Copy),
+                    (KeyCode::KeyX, true, true) => Key::Named(NamedKey::Cut),
+                    (KeyCode::KeyV, true, true) => Key::Named(NamedKey::Paste),
+                    (KeyCode::KeyZ, true, true) => Key::Named(NamedKey::Undo),
+                    (KeyCode::KeyY, true, true) => Key::Named(NamedKey::Redo),
+                    _ => logical_key,
+                };
+                RawEvent::Key {
+                    device_id,
+                    physical_key: PhysicalKey::Code(key),
+                    location,
+                    down,
+                    logical_key: k,
+                    modifiers,
+                }
+            }
+            _ => e,
+        }
+    }
+}
+
+impl super::EventStream for TextBoxState {
+    type Input = RawEvent;
+    type Output = TextBoxEvent;
+
+    fn process(
+        mut self,
+        input: Self::Input,
+        area: crate::AbsRect,
+        dpi: crate::Vec2,
+        driver: &std::sync::Weak<crate::Driver>,
+    ) -> eyre::Result<(Self, SmallVec<[Self::Output; 1]>), (Self, SmallVec<[Self::Output; 1]>)>
+    {
+        let obj = self.props.textedit().obj.clone();
+        let buffer = &mut obj.buffer.borrow_mut();
+        match Self::translate(input) {
+            RawEvent::Focus { acquired, window } => {
+                self.focused = acquired;
+                window.set_ime_allowed(acquired);
+                if acquired {
+                    window.set_ime_purpose(winit::window::ImePurpose::Normal);
+                    //window.set_ime_cursor_area(position, size);
+                }
+            }
+            RawEvent::Key {
+                down,
+                logical_key,
+                modifiers,
+                ..
+            } => match logical_key {
+                Key::Named(named_key) => {
+                    if down {
+                        if let Some(driver) = driver.upgrade() {
+                            let change = match named_key {
+                                NamedKey::Enter => self.editor.action(
+                                    &mut driver.font_system.write(),
+                                    buffer,
+                                    Action::Enter,
+                                ),
+                                NamedKey::Tab => self.editor.action(
+                                    &mut driver.font_system.write(),
+                                    buffer,
+                                    if (modifiers & ModifierKeys::Shift as u8) != 0 {
+                                        Action::Unindent
+                                    } else {
+                                        Action::Indent
+                                    },
+                                ),
+                                NamedKey::Space => self.editor.action(
+                                    &mut driver.font_system.write(),
+                                    buffer,
+                                    Action::Insert(' '),
+                                ),
+                                NamedKey::ArrowLeft
+                                | NamedKey::ArrowRight
+                                | NamedKey::ArrowDown
+                                | NamedKey::ArrowUp
+                                | NamedKey::End
+                                | NamedKey::Home
+                                | NamedKey::PageDown
+                                | NamedKey::PageUp => {
+                                    let ctrl = (modifiers & ModifierKeys::Control as u8) != 0;
+                                    let shift = (modifiers & ModifierKeys::Shift as u8) != 0;
+                                    let font_system = &mut driver.font_system.write();
+                                    if !shift {
+                                        match (named_key, ctrl) {
+                                            (NamedKey::ArrowUp, true)
+                                            | (NamedKey::ArrowDown, true) => {
+                                                self.editor.action(
+                                                    font_system,
+                                                    buffer,
+                                                    Action::Scroll {
+                                                        lines: if named_key == NamedKey::ArrowUp {
+                                                            -1
+                                                        } else {
+                                                            1
+                                                        },
+                                                    },
+                                                );
+                                                return Ok((self, SmallVec::new()));
+                                            }
+                                            _ => (),
+                                        }
+
+                                        if let Some((start, end)) =
+                                            self.editor.selection_bounds(buffer)
+                                        {
+                                            if named_key == NamedKey::ArrowLeft {
+                                                self.editor.set_cursor(buffer, start);
+                                            } else if named_key == NamedKey::ArrowRight {
+                                                self.editor.set_cursor(buffer, end);
+                                            }
+                                        }
+                                        self.editor.action(font_system, buffer, Action::Escape);
+                                    } else if self.editor.selection()
+                                        == cosmic_text::Selection::None
+                                    {
+                                        // if a selection doesn't exist, make one.
+                                        self.editor.set_selection(
+                                            buffer,
+                                            cosmic_text::Selection::Normal(self.editor.cursor()),
+                                        );
+                                    }
+                                    self.editor.action(
+                                        font_system,
+                                        buffer,
+                                        Action::Motion(match (named_key, ctrl) {
+                                            (NamedKey::ArrowLeft, false) => {
+                                                cosmic_text::Motion::Previous
+                                            }
+                                            (NamedKey::ArrowRight, false) => {
+                                                cosmic_text::Motion::Next
+                                            }
+                                            (NamedKey::ArrowUp, false) => cosmic_text::Motion::Up,
+                                            (NamedKey::ArrowDown, false) => {
+                                                cosmic_text::Motion::Down
+                                            }
+                                            (NamedKey::Home, false) => cosmic_text::Motion::Home,
+                                            (NamedKey::End, false) => cosmic_text::Motion::End,
+                                            (NamedKey::PageUp, false) => {
+                                                cosmic_text::Motion::PageUp
+                                            }
+                                            (NamedKey::PageDown, false) => {
+                                                cosmic_text::Motion::PageDown
+                                            }
+                                            (NamedKey::ArrowLeft, true) => {
+                                                cosmic_text::Motion::PreviousWord
+                                            }
+                                            (NamedKey::ArrowRight, true) => {
+                                                cosmic_text::Motion::NextWord
+                                            }
+                                            (NamedKey::Home, true) => {
+                                                cosmic_text::Motion::BufferStart
+                                            }
+                                            (NamedKey::End, true) => cosmic_text::Motion::BufferEnd,
+                                            _ => return Ok((self, SmallVec::new())),
+                                        }),
+                                    )
+                                }
+                                NamedKey::Select => {
+                                    // Represents a Select All operation
+                                    self.editor.set_selection(
+                                        buffer,
+                                        cosmic_text::Selection::Normal(Cursor {
+                                            line: 0,
+                                            index: 0,
+                                            affinity: cosmic_text::Affinity::Before,
+                                        }),
+                                    );
+                                    self.editor.action(
+                                        &mut driver.font_system.write(),
+                                        buffer,
+                                        Action::Motion(cosmic_text::Motion::BufferEnd),
+                                    );
+                                    SmallVec::new()
+                                }
+                                NamedKey::Backspace => self.editor.action(
+                                    &mut driver.font_system.write(),
+                                    buffer,
+                                    Action::Backspace,
+                                ),
+                                NamedKey::Delete => self.editor.action(
+                                    &mut driver.font_system.write(),
+                                    buffer,
+                                    Action::Delete,
+                                ),
+                                NamedKey::Clear => {
+                                    let change = self
+                                        .editor
+                                        .delete_selection(&mut driver.font_system.write(), buffer)
+                                        .map(|x| SmallVec::from_elem(x, 1))
+                                        .unwrap_or_default();
+                                    self.editor.shape_as_needed(
+                                        &mut driver.font_system.write(),
+                                        buffer,
+                                        false,
+                                    );
+                                    change
+                                }
+                                NamedKey::EraseEof => {
+                                    self.editor.set_selection(
+                                        buffer,
+                                        cosmic_text::Selection::Normal(self.editor.cursor()),
+                                    );
+                                    self.editor.action(
+                                        &mut driver.font_system.write(),
+                                        buffer,
+                                        Action::Motion(cosmic_text::Motion::BufferEnd),
+                                    );
+                                    let change = self
+                                        .editor
+                                        .delete_selection(&mut driver.font_system.write(), buffer)
+                                        .map(|x| SmallVec::from_elem(x, 1))
+                                        .unwrap_or_default();
+                                    self.editor.shape_as_needed(
+                                        &mut driver.font_system.write(),
+                                        buffer,
+                                        false,
+                                    );
+                                    change
+                                }
+                                NamedKey::Insert => {
+                                    self.insert_mode = !self.insert_mode;
+                                    SmallVec::new()
+                                }
+                                NamedKey::Cut | NamedKey::Copy => {
+                                    if modifiers & ModifierKeys::Held as u8 == 0 {
+                                        if let Some(s) = self.editor.copy_selection(buffer) {
+                                            if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                                                if clipboard.set_text(&s).is_ok()
+                                                    && named_key == NamedKey::Cut
+                                                {
+                                                    // Only delete the text for a cut command if the operation succeeds
+                                                    if let Some(c) = self.editor.delete_selection(
+                                                        &mut driver.font_system.write(),
+                                                        buffer,
+                                                    ) {
+                                                        self.editor.shape_as_needed(
+                                                            &mut driver.font_system.write(),
+                                                            buffer,
+                                                            false,
+                                                        );
+                                                        self.append(SmallVec::from_elem(c, 1))
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    SmallVec::new()
+                                }
+                                NamedKey::Paste => {
+                                    if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                                        if let Ok(s) = clipboard.get_text() {
+                                            let c = self.editor.insert_string(
+                                                &mut driver.font_system.write(),
+                                                buffer,
+                                                &s,
+                                                None,
+                                            );
+                                            self.editor.shape_as_needed(
+                                                &mut driver.font_system.write(),
+                                                buffer,
+                                                false,
+                                            );
+                                            self.append(SmallVec::from_elem(c, 1))
+                                        }
+                                    }
+                                    SmallVec::new()
+                                }
+                                NamedKey::Redo => {
+                                    if self.undo_index > 0 {
+                                        self.undo_index =
+                                            self.redo(&mut driver.font_system.write(), buffer)
+                                    }
+                                    SmallVec::new()
+                                }
+                                NamedKey::Undo => {
+                                    if self.undo_index > 0 {
+                                        self.undo_index =
+                                            self.undo(&mut driver.font_system.write(), buffer)
+                                    }
+                                    SmallVec::new()
+                                }
+                                // Do not capture key events we don't recognize
+                                _ => return Err((self, SmallVec::new())),
+                            };
+
+                            self.append(change);
+                            obj.set_selection(
+                                EditBuffer::from_cursor(buffer, self.editor.selection_or_cursor()),
+                                EditBuffer::from_cursor(buffer, self.editor.cursor()),
+                            );
+                            return Ok((self, SmallVec::new()));
+                        }
+                    }
+                    // Always capture the key event if we recognize it even if we don't do anything with it
+                    return Ok((self, SmallVec::new()));
+                }
+                Key::Character(c) => {
+                    if down {
+                        if let Some(driver) = driver.upgrade() {
+                            let c = self.editor.insert_string(
+                                &mut driver.font_system.write(),
+                                buffer,
+                                &c,
+                                None,
+                            );
+                            self.append(SmallVec::from_elem(c, 1));
+
+                            self.editor.shape_as_needed(
+                                &mut driver.font_system.write(),
+                                buffer,
+                                false,
+                            );
+                            obj.set_selection(
+                                EditBuffer::from_cursor(buffer, self.editor.selection_or_cursor()),
+                                EditBuffer::from_cursor(buffer, self.editor.cursor()),
+                            );
+                        }
+                        return Ok((self, SmallVec::new()));
+                    }
+                }
+                _ => (),
+            },
+            RawEvent::MouseMove {
+                pos, all_buttons, ..
+            } => {
+                if let Some(d) = driver.upgrade() {
+                    *d.cursor.write() = winit::window::CursorIcon::Text;
+                    let p = area.topleft() + self.props.padding().resolve(dpi).topleft();
+
+                    if (all_buttons & MouseButton::Left as u16) != 0 {
+                        self.editor.action(
+                            &mut d.font_system.write(),
+                            buffer,
+                            Action::Drag {
+                                x: (pos.x - p.x).round() as i32,
+                                y: (pos.y - p.y).round() as i32,
+                            },
+                        );
+                    }
+                }
+                obj.set_selection(
+                    EditBuffer::from_cursor(buffer, self.editor.selection_or_cursor()),
+                    EditBuffer::from_cursor(buffer, self.editor.cursor()),
+                );
+                return Ok((self, SmallVec::new()));
+            }
+            RawEvent::Mouse {
+                pos, state, button, ..
+            } => {
+                if let Some(d) = driver.upgrade() {
+                    let p = area.topleft() + self.props.padding().resolve(dpi).topleft();
+                    let action = match (state, button) {
+                        (MouseState::Down, MouseButton::Left) => Action::Click {
+                            x: (pos.x - p.x).round() as i32,
+                            y: (pos.y - p.y).round() as i32,
+                        },
+                        (MouseState::DblClick, MouseButton::Left) => Action::DoubleClick {
+                            x: (pos.x - p.x).round() as i32,
+                            y: (pos.y - p.y).round() as i32,
+                        },
+                        _ => return Ok((self, SmallVec::new())),
+                    };
+                    self.editor
+                        .action(&mut d.font_system.write(), buffer, action);
+                }
+                obj.set_selection(
+                    EditBuffer::from_cursor(buffer, self.editor.selection_or_cursor()),
+                    EditBuffer::from_cursor(buffer, self.editor.cursor()),
+                );
+                return Ok((self, SmallVec::new()));
+            }
+            RawEvent::MouseScroll { delta, pixels, .. } => {
+                if let Some(d) = driver.upgrade() {
+                    if pixels {
+                        let mut scroll = buffer.scroll();
+                        //TODO: align to layout lines
+                        scroll.vertical += delta.y;
+                        buffer.set_scroll(scroll);
+                    } else {
+                        self.editor.action(
+                            &mut d.font_system.write(),
+                            buffer,
+                            Action::Scroll {
+                                lines: -(delta.y.round() as i32),
+                            },
+                        );
+                    }
+                }
+            }
+            _ => (),
+        }
+        Err((self, SmallVec::new()))
+    }
 }
 
 impl Clone for TextBoxState {
@@ -45,6 +456,7 @@ impl Clone for TextBoxState {
             cursor_count: self.cursor_count.load(Ordering::Relaxed).into(),
             focused: self.focused,
             editor: self.editor.clone(),
+            props: self.props.clone(),
         }
     }
 }
@@ -59,6 +471,7 @@ impl PartialEq for TextBoxState {
             && self.cursor_count.load(Ordering::Relaxed)
                 == other.cursor_count.load(Ordering::Relaxed)
             && self.editor == other.editor
+            && Rc::ptr_eq(&self.props, &other.props)
     }
 }
 
@@ -76,27 +489,27 @@ pub struct TextBox<T: Prop + 'static> {
     pub weight: cosmic_text::Weight,
     pub style: cosmic_text::Style,
     pub wrap: cosmic_text::Wrap,
-    pub slots: [Option<crate::Slot>; 3], // TODO: TextBoxEvent::SIZE
+    pub slots: [Option<crate::Slot>; TextBoxEvent::SIZE],
 }
 
 impl TextBoxState {
-    fn redo(&mut self, font_system: &mut cosmic_text::FontSystem) -> usize {
+    fn redo(&mut self, font_system: &mut cosmic_text::FontSystem, buffer: &mut Buffer) -> usize {
         // Redo the current Edit event (or execute cursor events until we find one) then run all Cursor events after it until the next Edit event
         if self.undo_index < self.history.len() {
-            self.history[self.undo_index] = self
-                .editor
-                .apply_change(font_system, &self.history[self.undo_index]);
+            self.history[self.undo_index] =
+                self.editor
+                    .apply_change(font_system, buffer, &self.history[self.undo_index]);
             self.undo_index + 1
         } else {
             self.undo_index
         }
     }
 
-    fn undo(&mut self, font_system: &mut cosmic_text::FontSystem) -> usize {
+    fn undo(&mut self, font_system: &mut cosmic_text::FontSystem, buffer: &mut Buffer) -> usize {
         if self.undo_index > 0 {
-            self.history[self.undo_index - 1] = self
-                .editor
-                .apply_change(font_system, &self.history[self.undo_index - 1]);
+            self.history[self.undo_index - 1] =
+                self.editor
+                    .apply_change(font_system, buffer, &self.history[self.undo_index - 1]);
             self.undo_index - 1
         } else {
             self.undo_index
@@ -132,39 +545,7 @@ impl<T: Prop + 'static> TextBox<T> {
             weight,
             style,
             wrap,
-            slots: [None, None, None],
-        }
-    }
-
-    fn translate(e: RawEvent) -> RawEvent {
-        match e {
-            RawEvent::Key {
-                device_id,
-                physical_key: PhysicalKey::Code(key),
-                location,
-                down,
-                logical_key,
-                modifiers,
-            } => {
-                let k = match (key, down, modifiers & ModifierKeys::Control as u8 != 0) {
-                    (KeyCode::KeyA, true, true) => Key::Named(NamedKey::Select),
-                    (KeyCode::KeyC, true, true) => Key::Named(NamedKey::Copy),
-                    (KeyCode::KeyX, true, true) => Key::Named(NamedKey::Cut),
-                    (KeyCode::KeyV, true, true) => Key::Named(NamedKey::Paste),
-                    (KeyCode::KeyZ, true, true) => Key::Named(NamedKey::Undo),
-                    (KeyCode::KeyY, true, true) => Key::Named(NamedKey::Redo),
-                    _ => logical_key,
-                };
-                RawEvent::Key {
-                    device_id,
-                    physical_key: PhysicalKey::Code(key),
-                    location,
-                    down,
-                    logical_key: k,
-                    modifiers,
-                }
-            }
-            _ => e,
+            slots: [None],
         }
     }
 }
@@ -176,375 +557,11 @@ impl<T: Prop + 'static> crate::StateMachineChild for TextBox<T> {
 
     fn init(
         &self,
-        driver: &std::sync::Weak<crate::Driver>,
+        _: &std::sync::Weak<crate::Driver>,
     ) -> Result<Box<dyn super::StateMachineWrapper>, Error> {
-        let props = self.props.clone();
-        let driver = driver.clone();
-        let oninput = Box::new(crate::wrap_event::<RawEvent, TextBoxEvent, TextBoxState>(
-            move |e, area, dpi, mut data| {
-                let obj = &props.textedit().obj;
-                match Self::translate(e) {
-                    RawEvent::Focus { acquired, window } => {
-                        data.focused = acquired;
-                        window.set_ime_allowed(acquired);
-                        if acquired {
-                            window.set_ime_purpose(winit::window::ImePurpose::Normal);
-                            //window.set_ime_cursor_area(position, size);
-                        }
-                    }
-                    RawEvent::Key {
-                        down,
-                        logical_key,
-                        modifiers,
-                        ..
-                    } => match logical_key {
-                        Key::Named(named_key) => {
-                            if down {
-                                if let Some(driver) = driver.upgrade() {
-                                    let change = match named_key {
-                                        NamedKey::Enter => data
-                                            .editor
-                                            .action(&mut driver.font_system.write(), Action::Enter),
-                                        NamedKey::Tab => data.editor.action(
-                                            &mut driver.font_system.write(),
-                                            if (modifiers & ModifierKeys::Shift as u8) != 0 {
-                                                Action::Unindent
-                                            } else {
-                                                Action::Indent
-                                            },
-                                        ),
-                                        NamedKey::Space => data.editor.action(
-                                            &mut driver.font_system.write(),
-                                            Action::Insert(' '),
-                                        ),
-                                        NamedKey::ArrowLeft
-                                        | NamedKey::ArrowRight
-                                        | NamedKey::ArrowDown
-                                        | NamedKey::ArrowUp
-                                        | NamedKey::End
-                                        | NamedKey::Home
-                                        | NamedKey::PageDown
-                                        | NamedKey::PageUp => {
-                                            let ctrl =
-                                                (modifiers & ModifierKeys::Control as u8) != 0;
-                                            let shift =
-                                                (modifiers & ModifierKeys::Shift as u8) != 0;
-                                            let font_system = &mut driver.font_system.write();
-                                            if !shift {
-                                                match (named_key, ctrl) {
-                                                    (NamedKey::ArrowUp, true)
-                                                    | (NamedKey::ArrowDown, true) => {
-                                                        data.editor.action(
-                                                            font_system,
-                                                            Action::Scroll {
-                                                                lines: if named_key
-                                                                    == NamedKey::ArrowUp
-                                                                {
-                                                                    -1
-                                                                } else {
-                                                                    1
-                                                                },
-                                                            },
-                                                        );
-                                                        return Ok((data, vec![]));
-                                                    }
-                                                    _ => (),
-                                                }
-
-                                                if let Some((start, end)) =
-                                                    data.editor.selection_bounds()
-                                                {
-                                                    if named_key == NamedKey::ArrowLeft {
-                                                        data.editor.set_cursor(start);
-                                                    } else if named_key == NamedKey::ArrowRight {
-                                                        data.editor.set_cursor(end);
-                                                    }
-                                                }
-                                                data.editor.action(font_system, Action::Escape);
-                                            } else if data.editor.selection()
-                                                == cosmic_text::Selection::None
-                                            {
-                                                // if a selection doesn't exist, make one.
-                                                data.editor.set_selection(
-                                                    cosmic_text::Selection::Normal(
-                                                        data.editor.cursor(),
-                                                    ),
-                                                );
-                                            }
-                                            data.editor.action(
-                                                font_system,
-                                                Action::Motion(match (named_key, ctrl) {
-                                                    (NamedKey::ArrowLeft, false) => {
-                                                        cosmic_text::Motion::Previous
-                                                    }
-                                                    (NamedKey::ArrowRight, false) => {
-                                                        cosmic_text::Motion::Next
-                                                    }
-                                                    (NamedKey::ArrowUp, false) => {
-                                                        cosmic_text::Motion::Up
-                                                    }
-                                                    (NamedKey::ArrowDown, false) => {
-                                                        cosmic_text::Motion::Down
-                                                    }
-                                                    (NamedKey::Home, false) => {
-                                                        cosmic_text::Motion::Home
-                                                    }
-                                                    (NamedKey::End, false) => {
-                                                        cosmic_text::Motion::End
-                                                    }
-                                                    (NamedKey::PageUp, false) => {
-                                                        cosmic_text::Motion::PageUp
-                                                    }
-                                                    (NamedKey::PageDown, false) => {
-                                                        cosmic_text::Motion::PageDown
-                                                    }
-                                                    (NamedKey::ArrowLeft, true) => {
-                                                        cosmic_text::Motion::PreviousWord
-                                                    }
-                                                    (NamedKey::ArrowRight, true) => {
-                                                        cosmic_text::Motion::NextWord
-                                                    }
-                                                    (NamedKey::Home, true) => {
-                                                        cosmic_text::Motion::BufferStart
-                                                    }
-                                                    (NamedKey::End, true) => {
-                                                        cosmic_text::Motion::BufferEnd
-                                                    }
-                                                    _ => return Ok((data, vec![])),
-                                                }),
-                                            )
-                                        }
-                                        NamedKey::Select => {
-                                            // Represents a Select All operation
-                                            data.editor.set_selection(
-                                                cosmic_text::Selection::Normal(Cursor {
-                                                    line: 0,
-                                                    index: 0,
-                                                    affinity: cosmic_text::Affinity::Before,
-                                                }),
-                                            );
-                                            data.editor.action(
-                                                &mut driver.font_system.write(),
-                                                Action::Motion(cosmic_text::Motion::BufferEnd),
-                                            );
-                                            SmallVec::new()
-                                        }
-                                        NamedKey::Backspace => data.editor.action(
-                                            &mut driver.font_system.write(),
-                                            Action::Backspace,
-                                        ),
-                                        NamedKey::Delete => data.editor.action(
-                                            &mut driver.font_system.write(),
-                                            Action::Delete,
-                                        ),
-                                        NamedKey::Clear => {
-                                            let change = data
-                                                .editor
-                                                .delete_selection(&mut driver.font_system.write())
-                                                .map(|x| SmallVec::from_elem(x, 1))
-                                                .unwrap_or_default();
-                                            data.editor.shape_as_needed(
-                                                &mut driver.font_system.write(),
-                                                false,
-                                            );
-                                            change
-                                        }
-                                        NamedKey::EraseEof => {
-                                            data.editor.set_selection(
-                                                cosmic_text::Selection::Normal(
-                                                    data.editor.cursor(),
-                                                ),
-                                            );
-                                            data.editor.action(
-                                                &mut driver.font_system.write(),
-                                                Action::Motion(cosmic_text::Motion::BufferEnd),
-                                            );
-                                            let change = data
-                                                .editor
-                                                .delete_selection(&mut driver.font_system.write())
-                                                .map(|x| SmallVec::from_elem(x, 1))
-                                                .unwrap_or_default();
-                                            data.editor.shape_as_needed(
-                                                &mut driver.font_system.write(),
-                                                false,
-                                            );
-                                            change
-                                        }
-                                        NamedKey::Insert => {
-                                            data.insert_mode = !data.insert_mode;
-                                            SmallVec::new()
-                                        }
-                                        NamedKey::Cut | NamedKey::Copy => {
-                                            if modifiers & ModifierKeys::Held as u8 == 0 {
-                                                if let Some(s) = data.editor.copy_selection() {
-                                                    if let Ok(mut clipboard) =
-                                                        arboard::Clipboard::new()
-                                                    {
-                                                        if clipboard.set_text(&s).is_ok()
-                                                            && named_key == NamedKey::Cut
-                                                        {
-                                                            // Only delete the text for a cut command if the operation succeeds
-                                                            if let Some(c) =
-                                                                data.editor.delete_selection(
-                                                                    &mut driver.font_system.write(),
-                                                                )
-                                                            {
-                                                                data.editor.shape_as_needed(
-                                                                    &mut driver.font_system.write(),
-                                                                    false,
-                                                                );
-                                                                data.append(SmallVec::from_elem(
-                                                                    c, 1,
-                                                                ))
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            SmallVec::new()
-                                        }
-                                        NamedKey::Paste => {
-                                            if let Ok(mut clipboard) = arboard::Clipboard::new() {
-                                                if let Ok(s) = clipboard.get_text() {
-                                                    let c = data.editor.insert_string(
-                                                        &mut driver.font_system.write(),
-                                                        &s,
-                                                        None,
-                                                    );
-                                                    data.editor.shape_as_needed(
-                                                        &mut driver.font_system.write(),
-                                                        false,
-                                                    );
-                                                    data.append(SmallVec::from_elem(c, 1))
-                                                }
-                                            }
-                                            SmallVec::new()
-                                        }
-                                        NamedKey::Redo => {
-                                            if data.undo_index > 0 {
-                                                data.undo_index =
-                                                    data.redo(&mut driver.font_system.write())
-                                            }
-                                            SmallVec::new()
-                                        }
-                                        NamedKey::Undo => {
-                                            if data.undo_index > 0 {
-                                                data.undo_index =
-                                                    data.undo(&mut driver.font_system.write())
-                                            }
-                                            SmallVec::new()
-                                        }
-                                        // Do not capture key events we don't recognize
-                                        _ => return Err((data, vec![])),
-                                    };
-
-                                    data.append(change);
-                                    obj.set_selection(
-                                        obj.from_cursor(data.editor.selection_or_cursor()),
-                                        obj.from_cursor(data.editor.cursor()),
-                                    );
-                                    return Ok((data, vec![]));
-                                }
-                            }
-                            // Always capture the key event if we recognize it even if we don't do anything with it
-                            return Ok((data, vec![]));
-                        }
-                        Key::Character(c) => {
-                            if down {
-                                if let Some(driver) = driver.upgrade() {
-                                    let c = data.editor.insert_string(
-                                        &mut driver.font_system.write(),
-                                        &c,
-                                        None,
-                                    );
-                                    data.append(SmallVec::from_elem(c, 1));
-
-                                    data.editor
-                                        .shape_as_needed(&mut driver.font_system.write(), false);
-                                    obj.set_selection(
-                                        obj.from_cursor(data.editor.selection_or_cursor()),
-                                        obj.from_cursor(data.editor.cursor()),
-                                    );
-                                }
-                                return Ok((data, vec![]));
-                            }
-                        }
-                        _ => (),
-                    },
-                    RawEvent::MouseMove {
-                        pos, all_buttons, ..
-                    } => {
-                        if let Some(d) = driver.upgrade() {
-                            *d.cursor.write() = winit::window::CursorIcon::Text;
-                            let p = area.topleft() + props.padding().resolve(dpi).topleft();
-
-                            if (all_buttons & MouseButton::Left as u16) != 0 {
-                                data.editor.action(
-                                    &mut d.font_system.write(),
-                                    Action::Drag {
-                                        x: (pos.x - p.x).round() as i32,
-                                        y: (pos.y - p.y).round() as i32,
-                                    },
-                                );
-                            }
-                        }
-                        obj.set_selection(
-                            obj.from_cursor(data.editor.selection_or_cursor()),
-                            obj.from_cursor(data.editor.cursor()),
-                        );
-                        return Ok((data, vec![]));
-                    }
-                    RawEvent::Mouse {
-                        pos, state, button, ..
-                    } => {
-                        if let Some(d) = driver.upgrade() {
-                            let p = area.topleft() + props.padding().resolve(dpi).topleft();
-                            let action = match (state, button) {
-                                (MouseState::Down, MouseButton::Left) => Action::Click {
-                                    x: (pos.x - p.x).round() as i32,
-                                    y: (pos.y - p.y).round() as i32,
-                                },
-                                (MouseState::DblClick, MouseButton::Left) => Action::DoubleClick {
-                                    x: (pos.x - p.x).round() as i32,
-                                    y: (pos.y - p.y).round() as i32,
-                                },
-                                _ => return Ok((data, vec![])),
-                            };
-                            data.editor.action(&mut d.font_system.write(), action);
-                        }
-                        obj.set_selection(
-                            obj.from_cursor(data.editor.selection_or_cursor()),
-                            obj.from_cursor(data.editor.cursor()),
-                        );
-                        return Ok((data, vec![]));
-                    }
-                    RawEvent::MouseScroll { delta, pixels, .. } => {
-                        if let Some(d) = driver.upgrade() {
-                            if pixels {
-                                let mut buffer = data.editor.buffer_ref.borrow_mut();
-                                let mut scroll = buffer.scroll();
-                                //TODO: align to layout lines
-                                scroll.vertical += delta.y;
-                                buffer.set_scroll(scroll);
-                            } else {
-                                data.editor.action(
-                                    &mut d.font_system.write(),
-                                    Action::Scroll {
-                                        lines: -(delta.y.round() as i32),
-                                    },
-                                );
-                            }
-                        }
-                    }
-                    _ => (),
-                }
-                Err((data, vec![]))
-            },
-        ));
-
         let statemachine = StateMachine {
             state: Some(TextBoxState {
-                editor: Editor::new(self.props.textedit().obj.buffer.clone()),
+                editor: Editor::new(),
                 last_x_offset: Default::default(),
                 history: Default::default(),
                 undo_index: Default::default(),
@@ -552,17 +569,16 @@ impl<T: Prop + 'static> crate::StateMachineChild for TextBox<T> {
                 text_count: Default::default(),
                 cursor_count: Default::default(),
                 focused: Default::default(),
+                props: self.props.clone(),
             }),
-            input: [(
-                RawEventKind::Focus as u64
-                    | RawEventKind::Mouse as u64
-                    | RawEventKind::MouseMove as u64
-                    | RawEventKind::MouseScroll as u64
-                    | RawEventKind::Touch as u64
-                    | RawEventKind::Key as u64,
-                oninput,
-            )],
+            input_mask: RawEventKind::Focus as u64
+                | RawEventKind::Mouse as u64
+                | RawEventKind::MouseMove as u64
+                | RawEventKind::MouseScroll as u64
+                | RawEventKind::Touch as u64
+                | RawEventKind::Key as u64,
             output: self.slots.clone(),
+            changed: true,
         };
         Ok(Box::new(statemachine))
     }
@@ -571,19 +587,20 @@ impl<T: Prop + 'static> crate::StateMachineChild for TextBox<T> {
 impl<T: Prop + 'static> super::Component<T> for TextBox<T> {
     fn layout(
         &self,
-        state: &crate::StateManager,
+        state: &mut crate::StateManager,
         driver: &crate::graphics::Driver,
         window: &Rc<SourceID>,
-        _: &wgpu::SurfaceConfiguration,
     ) -> Box<dyn Layout<T>> {
         let winstate: &WindowStateMachine = state.get(window).unwrap();
         let winstate = winstate.state.as_ref().expect("No window state available");
         let dpi = winstate.dpi;
         let mut font_system = driver.font_system.write();
 
-        let textstate: &StateMachine<TextBoxEvent, TextBoxState, 1, 3> =
-            state.get(&self.id).unwrap();
-        let textstate = textstate.state.as_ref().unwrap();
+        let textstate: &mut StateMachine<TextBoxState, { TextBoxEvent::SIZE }> =
+            state.get_mut(&self.id).unwrap();
+        let textstate = textstate.state.as_mut().unwrap();
+        textstate.props = self.props.clone();
+
         if self.props.textedit().obj.reflow.load(Ordering::Acquire) {
             let attrs = cosmic_text::Attrs::new()
                 .family(self.font.as_family())
@@ -601,9 +618,11 @@ impl<T: Prop + 'static> super::Component<T> for TextBox<T> {
         }
 
         let instance = crate::render::textbox::Instance {
-            text_buffer: textstate.editor.buffer_ref.clone(),
+            text_buffer: self.props.textedit().obj.buffer.clone(),
             padding: self.props.padding().resolve(dpi),
-            selection: textstate.editor.selection_bounds(),
+            selection: textstate
+                .editor
+                .selection_bounds(&self.props.textedit().obj.buffer.borrow()),
             color: self.color,
             cursor_color: if textstate.focused {
                 self.color
@@ -620,7 +639,7 @@ impl<T: Prop + 'static> super::Component<T> for TextBox<T> {
             props: self.props.clone(),
             id: Rc::downgrade(&self.id),
             renderable: Rc::new(instance),
-            buffer: textstate.editor.buffer_ref.clone(),
+            buffer: self.props.textedit().obj.buffer.clone(),
         })
     }
 }

--- a/feather-ui/src/layout/flex.rs
+++ b/feather-ui/src/layout/flex.rs
@@ -365,16 +365,16 @@ impl Desc for dyn Prop {
         // Note that margins only ever apply between elements, not edges, so we completely ignore the
         // off-axis margin, as this calculation assumes there is only 1 line of items, and the off-axis
         // margin doesn't apply until there are linebreaks.
-        let fold = VectorFold::new(
-            |prev: &(f32, f32, f32), n: &Option<ChildCache>| -> (f32, f32, f32) {
-                let cache = n.as_ref().unwrap();
-                (
-                    cache.basis + prev.0 + merge_margin(prev.2, cache.margin.topleft().x),
-                    cache.aux.max(prev.1),
-                    cache.margin.bottomright().x,
-                )
-            },
-        );
+        let mut fold = VectorFold::new(&|prev: &(f32, f32, f32),
+                                         n: &Option<ChildCache>|
+         -> (f32, f32, f32) {
+            let cache = n.as_ref().unwrap();
+            (
+                cache.basis + prev.0 + merge_margin(prev.2, cache.margin.topleft().x),
+                cache.aux.max(prev.1),
+                cache.margin.bottomright().x,
+            )
+        });
 
         let (_, (used_main, used_aux, _)) =
             fold.call(fold.init(), &(0.0, 0.0, f32::NAN), &childareas);

--- a/feather-ui/src/layout/mod.rs
+++ b/feather-ui/src/layout/mod.rs
@@ -152,8 +152,7 @@ impl Concrete {
         let (unsized_x, unsized_y) = check_unsized_abs(area.bottomright());
         assert!(
             !unsized_x && !unsized_y,
-            "concrete area must always be sized!: {:?}",
-            area
+            "concrete area must always be sized!: {area:?}",
         );
         Self {
             renderable,

--- a/feather-ui/src/layout/text.rs
+++ b/feather-ui/src/layout/text.rs
@@ -64,8 +64,16 @@ impl<T: leaf::Padded> Layout<T> for Node<T> {
 
             text_buffer.set_size(
                 &mut font_system,
-                if unsized_x { limitx } else { Some(dim.x) },
-                if unsized_y { limity } else { Some(dim.y) },
+                if unsized_x {
+                    limitx
+                } else {
+                    Some(dim.x.max(0.0))
+                },
+                if unsized_y {
+                    limity
+                } else {
+                    Some(dim.y.max(0.0))
+                },
             );
         }
 

--- a/feather-ui/src/lua.rs
+++ b/feather-ui/src/lua.rs
@@ -365,12 +365,12 @@ impl FnPersist<AppState, im::HashMap<Rc<SourceID>, Option<Window>>> for LuaApp {
         let r = self.init.call::<LuaValue>(());
         match r {
             Err(LuaError::RuntimeError(s)) => panic!("{}", s),
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!("{e:?}"),
             Ok(v) => v,
         }
     }
     fn call(
-        &self,
+        &mut self,
         store: Self::Store,
         args: &AppState,
     ) -> (Self::Store, im::HashMap<Rc<SourceID>, Option<Window>>) {

--- a/feather-ui/src/render/atlas.rs
+++ b/feather-ui/src/render/atlas.rs
@@ -207,9 +207,6 @@ impl Atlas {
         }
         assert_ne!(dim.width, 0);
         assert_ne!(dim.height, 0);
-        if dim.width > self.extent as i32 || dim.height > self.extent as i32 {
-            panic!("Requested reservation size exceeds size of texture atlas!")
-        }
 
         for (idx, a) in self.allocators.iter_mut().enumerate() {
             if let Some(r) = a.allocate(dim) {
@@ -219,6 +216,13 @@ impl Atlas {
 
         // If we run out of room, try adding another layer
         self.grow(device)?;
+
+        if dim.width > self.extent as i32 || dim.height > self.extent as i32 {
+            panic!(
+                "Requested reservation size ({},{}) exceeds size of texture atlas ({},{})!",
+                dim.width, dim.height, self.extent, self.extent
+            )
+        }
 
         if let Some(r) = self
             .allocators

--- a/feather-ui/src/text.rs
+++ b/feather-ui/src/text.rs
@@ -183,10 +183,10 @@ impl EditBuffer {
         self.count.fetch_add(1, Ordering::Release);
     }
 
-    pub fn to_cursor(&self, cursor: (usize, Affinity)) -> Cursor {
+    pub fn to_cursor(buffer: &crate::cosmic_text::Buffer, cursor: (usize, Affinity)) -> Cursor {
         let mut lines = 0;
         let (mut idx, mut affinity) = cursor;
-        for line in &self.buffer.borrow().lines {
+        for line in &buffer.lines {
             let len = line.text().len();
             if len >= idx {
                 break;
@@ -207,9 +207,9 @@ impl EditBuffer {
         }
     }
 
-    pub fn from_cursor(&self, cursor: Cursor) -> (usize, Affinity) {
+    pub fn from_cursor(buffer: &crate::cosmic_text::Buffer, cursor: Cursor) -> (usize, Affinity) {
         let mut idx = 0;
-        for line in self.buffer.borrow().lines.iter().take(cursor.line) {
+        for line in buffer.lines.iter().take(cursor.line) {
             idx += line.text().len() + line.ending().as_str().len();
         }
         (idx + cursor.index, cursor.affinity)

--- a/feather-ui/src/util.rs
+++ b/feather-ui/src/util.rs
@@ -25,13 +25,13 @@ pub fn create_hotloader<T: 'static>(
                 let module = shaders::load_wgsl(&driver.device, label, &prev);
                 let err = futures_lite::future::block_on(driver.device.pop_error_scope());
                 if let Some(e) = err {
-                    println!("{}", e);
+                    println!("{e}");
                 } else {
                     let info = futures_lite::future::block_on(module.get_compilation_info());
 
                     let mut errored = false;
                     for m in info.messages {
-                        println!("{:?}", m);
+                        println!("{m:?}");
                         errored = errored || m.message_type == CompilationMessageType::Error;
                     }
                     if !errored {


### PR DESCRIPTION
This makes the event stream architecture explicit, simplifies implementing them, and fixes a bunch of bugs that were being hidden by the previous approach, which required adding mutability to the state during the outline pass so that properties can be propagated to the state as there is no other way to propagate this information (since the outline node doesn't even exist by the time we reach layout phase).

Includes refactors requested by clippy due to upgrading to rust 1.88