### PR TITLE
Cache shape pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "color"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae467d04a8a8aea5d9a49018a6ade2e4221d92968e8ce55a48c0b1164e5f698"
+checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
 
 [[package]]
 name = "color_quant"
@@ -872,12 +872,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1177,7 +1177,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -1201,7 +1201,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.5+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1436,9 +1436,9 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1803,9 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "lebe"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
@@ -1867,9 +1867,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litrs"
@@ -2772,7 +2772,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-sys 0.60.2",
 ]
 
@@ -2867,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "376f733579ac4d3b9fbf0afca99bf8f6b698d541118affca554d0b86f73c2470"
+checksum = "f55f4fedc84ed39cb7a489322318976425e42a147e2be79d8f878e2884f94e84"
 dependencies = [
  "num-traits",
 ]
@@ -3146,15 +3146,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3581,15 +3581,15 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3838,9 +3838,9 @@ checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4142,9 +4142,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen",
 ]
@@ -4229,7 +4238,7 @@ checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -4242,7 +4251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags 2.9.4",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -4264,7 +4273,7 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447ccc440a881271b19e9989f75726d60faa09b95b0200a9b7eb5cc47c3eeb29"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "wayland-client",
  "xcursor",
 ]
@@ -4631,7 +4640,7 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "winsafe",
 ]
 
@@ -4647,11 +4656,11 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4704,6 +4713,12 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-result"
@@ -4761,6 +4776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4797,7 +4821,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -5060,7 +5084,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "x11rb-protocol",
 ]
 
@@ -5121,18 +5145,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Fundament Research Institute <https://fundament.institute>
+
+[default.extend-words]
+ot = "ot"
+MERCHANTIBILITY = "MERCHANTIBILITY"

--- a/feather-ui/src/color.rs
+++ b/feather-ui/src/color.rs
@@ -76,7 +76,7 @@ pub trait ColorSpace: Premultiplied {
     fn xyz(&self) -> XYZ;
 
     /// This uses the standard formulation to transform into OkLab from XYZ
-    /// but this can be overriden if there's a more efficient pathway
+    /// but this can be overridden if there's a more efficient pathway
     fn oklab(&self) -> OkLab {
         let xyz = self.xyz();
 
@@ -102,7 +102,7 @@ pub trait ColorSpace: Premultiplied {
         }
     }
 
-    /// This automatically converts from XYZ, but can be overriden if there's a faster pathway
+    /// This automatically converts from XYZ, but can be overridden if there's a faster pathway
     fn linear_srgb(&self) -> Raw_sRGB<true, false> {
         let xyz = self.xyz();
 

--- a/feather-ui/src/component/shape.rs
+++ b/feather-ui/src/component/shape.rs
@@ -4,7 +4,6 @@
 use crate::color::sRGB;
 use crate::layout::{Layout, leaf};
 use crate::{DAbsPoint, SourceID};
-use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -265,9 +264,7 @@ where
             props: self.props.clone(),
             id: Arc::downgrade(&self.id),
             size: self.size.resolve(dpi).to_vector().to_size().cast_unit(),
-            renderable: Some(Rc::new(crate::render::shape::Instance::<
-                crate::render::shape::Shape<KIND>,
-            > {
+            renderable: Some(Rc::new(crate::render::shape::Instance::<KIND> {
                 padding: self.props.padding().as_perimeter(dpi),
                 border: self.border,
                 blur: self.blur,
@@ -275,7 +272,6 @@ where
                 outline: self.outline,
                 corners,
                 id: self.id.clone(),
-                phantom: PhantomData,
             })),
         })
     }

--- a/feather-ui/src/graphics.rs
+++ b/feather-ui/src/graphics.rs
@@ -34,9 +34,7 @@ pub(crate) struct PipelineState {
     shader: ShaderModule,
     #[derive_where(skip)]
     generator: Box<
-        dyn Fn(&PipelineLayout, &ShaderModule, &Driver) -> Box<dyn render::AnyPipeline>
-            + Send
-            + Sync,
+        dyn Fn(&PipelineLayout, &ShaderModule, &Driver) -> Box<dyn render::Pipeline> + Send + Sync,
     >,
 }
 
@@ -116,7 +114,7 @@ pub struct Driver {
     pub(crate) layer_atlas: [RwLock<Atlas>; 2],
     pub(crate) layer_composite: [RwLock<compositor::Compositor>; 2],
     pub(crate) shared: compositor::Shared,
-    pub(crate) pipelines: RwLock<HashMap<PipelineID, Box<dyn crate::render::AnyPipeline>>>,
+    pub(crate) pipelines: RwLock<HashMap<PipelineID, Box<dyn crate::render::Pipeline>>>,
     pub(crate) registry: RwLock<HashMap<PipelineID, PipelineState>>,
     pub(crate) queue: wgpu::Queue,
     pub(crate) device: wgpu::Device,
@@ -129,6 +127,10 @@ pub struct Driver {
 
 impl Drop for Driver {
     fn drop(&mut self) {
+        for (_, mut p) in self.pipelines.write().drain() {
+            p.destroy(self);
+        }
+
         for (_, mut r) in self.glyphs.get_mut().drain() {
             r.region.id = AllocId::deserialize(u32::MAX);
         }
@@ -247,7 +249,7 @@ impl Driver {
         &mut self,
         layout: PipelineLayout,
         shader: ShaderModule,
-        generator: impl Fn(&PipelineLayout, &ShaderModule, &Self) -> Box<dyn render::AnyPipeline>
+        generator: impl Fn(&PipelineLayout, &ShaderModule, &Self) -> Box<dyn render::Pipeline>
         + Send
         + Sync
         + 'static,
@@ -272,7 +274,10 @@ impl Driver {
         pipeline.shader = shader;
         self.pipelines.write().remove(&id);
     }
-    pub fn with_pipeline<T: crate::render::Pipeline + 'static>(&self, f: impl FnOnce(&mut T)) {
+    pub fn with_pipeline<T: crate::render::Pipeline + 'static, R>(
+        &self,
+        f: impl FnOnce(&mut T) -> R,
+    ) -> R {
         let id = TypeId::of::<T>();
 
         // We can't use the result of this because it makes the lifetimes weird
@@ -292,7 +297,7 @@ impl Driver {
             (self.pipelines.write().get_mut(&id).unwrap().as_mut() as &mut dyn std::any::Any)
                 .downcast_mut()
                 .unwrap(),
-        );
+        )
     }
 
     pub fn prefetch(&self, location: &dyn Location) -> Result<(), Error> {
@@ -305,7 +310,7 @@ impl Driver {
     }
 
     /// This function is called during layout, outside of a render pass, which allows the texture atlas to be
-    /// immediately resized to accomdate the new resource. As a result, it assumes you don't need the region,
+    /// immediately resized to accommodate the new resource. As a result, it assumes you don't need the region,
     /// only the final intrinsic size.
     pub fn load_and_resize(
         &self,
@@ -470,20 +475,45 @@ pub struct Vec2f(pub(crate) [f32; 2]);
 
 gen_from_array!(Vec2f, f32, 2);
 
+static_assertions::assert_eq_size!(Vec2f, [f32; 2]);
+
+impl std::hash::Hash for Vec2f {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        use crate::Canonicalize;
+        self.0.map(|x| x.canonical_bits()).hash(state);
+    }
+}
+
+impl std::ops::AddAssign<[f32; 2]> for Vec2f {
+    fn add_assign(&mut self, rhs: [f32; 2]) {
+        self.0[0] += rhs[0];
+        self.0[1] += rhs[1];
+    }
+}
+
 #[repr(C, align(16))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, bytemuck::NoUninit)]
 pub struct Vec4f(pub(crate) [f32; 4]);
 
 gen_from_array!(Vec4f, f32, 4);
 
+static_assertions::assert_eq_size!(Vec4f, [f32; 4]);
+
+impl std::hash::Hash for Vec4f {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        use crate::Canonicalize;
+        self.0.map(|x| x.canonical_bits()).hash(state);
+    }
+}
+
 #[repr(C, align(8))]
-#[derive(Clone, Copy, Debug, Default, PartialEq, bytemuck::NoUninit)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Hash, bytemuck::NoUninit)]
 pub struct Vec2i(pub(crate) [i32; 2]);
 
 gen_from_array!(Vec2i, i32, 2);
 
 #[repr(C, align(16))]
-#[derive(Clone, Copy, Debug, Default, PartialEq, bytemuck::NoUninit)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Hash, bytemuck::NoUninit)]
 pub struct Vec4i(pub(crate) [i32; 4]);
 
 gen_from_array!(Vec4i, i32, 4);

--- a/feather-ui/src/lib.rs
+++ b/feather-ui/src/lib.rs
@@ -129,7 +129,7 @@ pub enum Error {
     UnknownResourceFormat,
     #[error("An index was out of range: {0}")]
     OutOfRange(usize),
-    #[error("Type mismatch occured when attempting a downcast that should never fail!")]
+    #[error("Type mismatch occurred when attempting a downcast that should never fail!")]
     RuntimeTypeMismatch,
 }
 
@@ -139,7 +139,7 @@ impl From<std::io::Error> for Error {
     }
 }
 
-/// Represents an axis that is "unsized", which is roughly equivelent to CSS `auto`. It will
+/// Represents an axis that is "unsized", which is roughly equivalent to CSS `auto`. It will
 /// set the size of the axis either to the size of the children, if the layout has any, or to
 /// the intrinsic size of the element, if one exists. Otherwise it will evaluate to 0.
 pub const UNSIZED_AXIS: f32 = f32::MAX;
@@ -284,6 +284,33 @@ pub struct Rect<U> {
     pub v: f32x4,
     #[doc(hidden)]
     pub _unit: PhantomData<U>,
+}
+
+/// This trait is used to canonicalize floats into forms suitable for hashing. Because
+/// NaNs should never get this far in the pipeline, we only care about the +0.0 and -0.0
+/// problem, which can be solved because IEEE defines -0.0 plus +0.0 to equal +0.0.
+trait Canonicalize {
+    type Bits;
+
+    fn canonical_bits(self) -> Self::Bits;
+}
+
+impl Canonicalize for f32 {
+    type Bits = u32;
+
+    fn canonical_bits(self) -> Self::Bits {
+        debug_assert!(!self.is_nan()); // In debug mode, ensure this is not a NaN
+        (self + 0.0).to_bits()
+    }
+}
+
+impl Canonicalize for f64 {
+    type Bits = u64;
+
+    fn canonical_bits(self) -> Self::Bits {
+        debug_assert!(!self.is_nan()); // In debug mode, ensure this is not a NaN
+        (self + 0.0).to_bits()
+    }
 }
 
 /// A 2D rectangle in logical units (display-independent pixels)
@@ -1960,7 +1987,7 @@ impl<'a> ScopeID<'a> {
         ScopeIterID::new(self, other.into_iter())
     }
 
-    /// Wraps the true and false branches of a condition, ensuring the IDs for both are maintained seperately
+    /// Wraps the true and false branches of a condition, ensuring the IDs for both are maintained separately
     /// regardless of which branch is picked.
     ///
     /// # Examples

--- a/feather-ui/src/persist.rs
+++ b/feather-ui/src/persist.rs
@@ -32,7 +32,7 @@ impl<Arg1, Arg2, Output, T: FnMut(Arg1, Arg2) -> Output> Persist2<Arg1, Arg2, Ou
 
 /// This represents the storage of a persistent function. This trait is shared between all [`FnPersist`]
 /// traits for each distinct number of arguments. The storage type must satisfy [`Clone`] and should ideally
-/// be built using persistent data structures. In order to allow a persisten function to work correctly,
+/// be built using persistent data structures. In order to allow a persistent function to work correctly,
 /// Store should have space to store both the *input arguments* and the *output result* of a persistent
 /// function. This is essential to allowing a persistent function to detect that it's arguments are the same
 /// as the previous invocation and return the previous output without any additional computation.

--- a/feather-ui/src/render/atlas.rs
+++ b/feather-ui/src/render/atlas.rs
@@ -46,6 +46,7 @@ pub struct Atlas {
 // TODO: Should be possible to define an HDR pipeline with 16-bit channels
 pub const ATLAS_FORMAT: TextureFormat = TextureFormat::Bgra8UnormSrgb;
 const ATLAS_MIP_LEVELS: u32 = 8;
+pub type PxBox = guillotiere::euclid::Box2D<i32, Pixel>;
 
 impl Drop for Atlas {
     fn drop(&mut self) {
@@ -666,7 +667,7 @@ impl Atlas {
 /// A single allocated region on a particular texture atlas. We store the pixel coordinates, not the normalized UV coordinates.
 pub struct Region {
     pub id: AllocId,
-    pub uv: guillotiere::euclid::Box2D<i32, Pixel>,
+    pub uv: PxBox,
     pub index: u8,
 }
 

--- a/feather-ui/src/render/compositor.rs
+++ b/feather-ui/src/render/compositor.rs
@@ -3,7 +3,8 @@
 
 use crate::color::sRGB32;
 use crate::graphics::{Driver, Vec2f};
-use crate::{Pixel, PxDim, PxPoint, PxRect, PxVector, RelDim, SourceID};
+use crate::render::atlas::PxBox;
+use crate::{PxDim, PxPoint, PxRect, PxVector, RelDim, SourceID};
 use derive_where::derive_where;
 use num_traits::Zero;
 use smallvec::SmallVec;
@@ -917,12 +918,7 @@ impl<'a> CompositorView<'a> {
     }
 
     #[inline]
-    pub(crate) fn append_layer(
-        &mut self,
-        layer: &Layer,
-        parent_pos: PxPoint,
-        uv: guillotiere::euclid::Box2D<i32, Pixel>,
-    ) -> u32 {
+    pub(crate) fn append_layer(&mut self, layer: &Layer, parent_pos: PxPoint, uv: PxBox) -> u32 {
         // I really wish rust had partial borrows
         let compositor = match self.index {
             0 => &mut self.window,

--- a/feather-ui/src/render/mod.rs
+++ b/feather-ui/src/render/mod.rs
@@ -25,10 +25,6 @@ pub trait Renderable {
 }
 
 pub trait Pipeline: Any + std::fmt::Debug + Send + Sync {
-    type Data: 'static;
-
-    fn append(&mut self, data: &Self::Data, layer: u8);
-
     #[allow(unused_variables)]
     fn prepare(
         &mut self,
@@ -38,34 +34,8 @@ pub trait Pipeline: Any + std::fmt::Debug + Send + Sync {
     ) {
     }
     fn draw(&mut self, driver: &graphics::Driver, pass: &mut wgpu::RenderPass<'_>, layer: u8);
-}
-
-pub trait AnyPipeline: Any + std::fmt::Debug + Send + Sync {
-    fn append(&mut self, data: &dyn Any, layer: u8);
-    fn prepare(
-        &mut self,
-        driver: &graphics::Driver,
-        encoder: &mut wgpu::CommandEncoder,
-        config: &wgpu::SurfaceConfiguration,
-    );
-    fn draw(&mut self, driver: &graphics::Driver, pass: &mut wgpu::RenderPass<'_>, layer: u8);
-}
-
-impl<T: Pipeline + std::fmt::Debug + Send + Sync + 'static> AnyPipeline for T {
-    fn append(&mut self, data: &dyn Any, layer: u8) {
-        Pipeline::append(self, data.downcast_ref().unwrap(), layer)
-    }
-    fn prepare(
-        &mut self,
-        driver: &graphics::Driver,
-        encoder: &mut wgpu::CommandEncoder,
-        config: &wgpu::SurfaceConfiguration,
-    ) {
-        Pipeline::prepare(self, driver, encoder, config);
-    }
-    fn draw(&mut self, driver: &graphics::Driver, pass: &mut wgpu::RenderPass<'_>, layer: u8) {
-        Pipeline::draw(self, driver, pass, layer);
-    }
+    #[allow(unused_variables)]
+    fn destroy(&mut self, driver: &graphics::Driver) {}
 }
 
 pub struct Chain<const N: usize>(pub [Rc<dyn Renderable>; N]);

--- a/feather-ui/src/render/shape.rs
+++ b/feather-ui/src/render/shape.rs
@@ -5,32 +5,28 @@ use super::compositor;
 use crate::color::sRGB;
 use crate::component::shape::ShapeKind;
 use crate::graphics::{self, Vec2f, Vec4f};
-use crate::render::atlas::Atlas;
+use crate::render::atlas::{self, Atlas};
 use crate::render::compositor::CompositorView;
-use crate::{PxDim, PxPoint, shaders};
+use crate::{Canonicalize, PxDim, PxPoint, SourceID, shaders};
 use core::f32;
 use guillotiere::euclid::Size2D;
 use num_traits::Zero;
-use std::any::TypeId;
 use std::collections::HashMap;
-use std::marker::PhantomData;
 use std::num::NonZero;
+use std::sync::Arc;
 use wgpu::BindGroupLayout;
 
-pub struct Instance<PIPELINE> {
+pub struct Instance<const KIND: u8> {
     pub padding: crate::PxPerimeter,
     pub border: f32,
     pub blur: f32,
     pub fill: sRGB,
     pub outline: sRGB,
     pub corners: [f32; 4],
-    pub id: std::sync::Arc<crate::SourceID>,
-    pub phantom: PhantomData<PIPELINE>,
+    pub id: Arc<SourceID>,
 }
 
-impl<PIPELINE: crate::render::Pipeline<Data = Data> + 'static> super::Renderable
-    for Instance<PIPELINE>
-{
+impl<const KIND: u8> super::Renderable for Instance<KIND> {
     fn render(
         &self,
         area: crate::PxRect,
@@ -67,9 +63,7 @@ impl<PIPELINE: crate::render::Pipeline<Data = Data> + 'static> super::Renderable
         ];
 
         // RoundRects have a specific optimization, but only if no edge length is less than 2 pixels
-        if TypeId::of::<PIPELINE>() == TypeId::of::<Shape<{ ShapeKind::RoundRect as u8 }>>()
-            && perimeter.iter().all(|x| *x >= 2.0)
-        {
+        if KIND == ShapeKind::RoundRect as u8 && perimeter.iter().all(|x| *x >= 2.0) {
             // If the border is larger than the corner itself, pretend the size of that corner is the border.
             let mut corners = self.corners.map(|x| x.max(self.border));
             let mut intcorners = corners.map(|x| x.ceil() as i32);
@@ -82,48 +76,36 @@ impl<PIPELINE: crate::render::Pipeline<Data = Data> + 'static> super::Renderable
             ];
 
             // Here we generate a rounded block equal to exactly left side + 3 pixels + right side
-            let inner = Size2D::<i32, crate::Pixel>::new(
+            let inner = atlas::Size::new(
                 intsides[0] + intsides[2] + 3, // left + right
                 intsides[1] + intsides[3] + 3, // top + bottom
             );
 
-            // TODO: cache this if the inputs are identical
             // We reserve an additional 2 pixel border around each side of our rect for sampling purposes. It
             // must be 2 pixels because we have to inflate the rect by 1 pixel for fractional draws already,
             // which means we need an additional transparent pixel of buffer to cover all possible sampling
             // scenarios.
-            let (region_uv, region_index) = {
-                let mut atlas = driver.atlas.write();
-                let region = atlas.cache_region(
-                    &driver.device,
-                    &self.id,
-                    inner + Size2D::<i32, crate::Pixel>::new(4, 4),
-                    None,
-                    Some(&driver.queue),
-                )?;
-                (region.uv, region.index)
-            };
-
-            // We render the rect here with corners raised to the nearest pixel so we can cut out the corners neatly
-            driver.with_pipeline::<PIPELINE>(|pipeline| {
-                pipeline.append(
-                    &Data {
-                        pos: region_uv
-                            .min
-                            .add_size(&Size2D::splat(2))
-                            .to_f32()
-                            .to_array()
-                            .into(),
-                        dim: inner.to_f32().to_array().into(),
-                        border: self.border,
-                        blur: self.blur,
-                        corners: intcorners.map(|x| x as f32).into(),
-                        fill: self.fill.as_32bit().rgba,
-                        outline: self.outline.as_32bit().rgba,
+            let (region_uv, region_index) = driver
+                .with_pipeline::<Shape<KIND>, Result<(atlas::PxBox, u8), crate::Error>>(
+                    |pipeline| {
+                        pipeline.reserve(
+                            driver,
+                            self.id.clone(),
+                            inner + atlas::Size::new(4, 4),
+                            Data {
+                                pos: [2.0; 2].into(),
+                                dim: inner.to_f32().to_array().into(),
+                                border: self.border,
+                                blur: self.blur,
+                                // We use corners raised to the nearest pixel so we can cut out the corners neatly
+                                corners: intcorners.map(|x| x as f32).into(),
+                                fill: self.fill.as_32bit().rgba,
+                                outline: self.outline.as_32bit().rgba,
+                            },
+                            true,
+                        )
                     },
-                    region_index,
-                )
-            });
+                )?;
 
             // The only reason this works is because we set the uvdim here to 0 on the axis that is being
             // extended, which ensures no interpolation of the UV coordinate happens along that axis
@@ -264,34 +246,30 @@ impl<PIPELINE: crate::render::Pipeline<Data = Data> + 'static> super::Renderable
             return Ok(());
         }
 
-        let (region_uv, region_index) = {
-            let mut atlas = driver.atlas.write();
-            let region =
-                atlas.cache_region(&driver.device, &self.id, dim.ceil().cast(), None, None)?;
-            (region.uv, region.index)
-        };
-
         // The region dimensions here can be wrong, because the region is rounded up to the nearest pixel.
         // However, properly fixing this requires changing how the SDF shader works so it can properly
         // emulate conservative rasterization. For now, we keep our original behavior of rounding up and
         // then letting the compositor squish the result slightly, which is actually pretty accurate.
         // TODO: Change this to be pixel-perfect by outputting the exact dimensions instead of rounded ones.
 
-        // TODO: cache this if the inputs are identical
-        driver.with_pipeline::<PIPELINE>(|pipeline| {
-            pipeline.append(
-                &Data {
-                    pos: region_uv.min.to_f32().to_array().into(),
-                    dim: region_uv.size().to_f32().to_array().into(),
-                    border: self.border,
-                    blur: self.blur,
-                    corners: self.corners.into(),
-                    fill: self.fill.as_32bit().rgba,
-                    outline: self.outline.as_32bit().rgba,
-                },
-                region_index,
-            )
-        });
+        let (region_uv, region_index) = driver
+            .with_pipeline::<Shape<KIND>, Result<(atlas::PxBox, u8), crate::Error>>(|pipeline| {
+                pipeline.reserve(
+                    driver,
+                    self.id.clone(),
+                    dim.ceil().cast(),
+                    Data {
+                        pos: [0.0; 2].into(),
+                        dim: dim.to_array().into(),
+                        border: self.border,
+                        blur: self.blur,
+                        corners: self.corners.into(),
+                        fill: self.fill.as_32bit().rgba,
+                        outline: self.outline.as_32bit().rgba,
+                    },
+                    false,
+                )
+            })?;
 
         compositor.append_data(
             area.topleft().add_size(&self.padding.topleft()),
@@ -320,6 +298,7 @@ impl<PIPELINE: crate::render::Pipeline<Data = Data> + 'static> super::Renderable
 // };
 // Data d[];
 
+// TODO: Maybe use NotNaN from ordered_float if this doesn't mess up alignment?
 #[derive(Debug, Clone, Copy, Default, PartialEq, bytemuck::NoUninit)]
 #[repr(C)]
 pub struct Data {
@@ -332,21 +311,96 @@ pub struct Data {
     pub outline: u32,
 }
 
+// We manually implement Eq because no NaNs should be in Data
+impl Eq for Data {}
+
+impl std::hash::Hash for Data {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.corners.hash(state);
+        self.pos.hash(state);
+        self.dim.hash(state);
+        self.border.canonical_bits().hash(state);
+        self.blur.canonical_bits().hash(state);
+        self.fill.hash(state);
+        self.outline.hash(state);
+    }
+}
+
 #[derive(Debug)]
 pub struct Shape<const KIND: u8> {
     data: HashMap<u8, Vec<Data>>,
     buffer: wgpu::Buffer,
     pipeline: wgpu::RenderPipeline,
     group: wgpu::BindGroup,
+    cache: HashMap<Arc<SourceID>, (Data, atlas::PxBox, u8)>,
+    refcount: HashMap<(Data, atlas::Size), (atlas::Region, usize)>,
+}
+
+impl<const KIND: u8> Shape<KIND> {
+    fn reserve(
+        &mut self,
+        driver: &graphics::Driver,
+        id: Arc<SourceID>,
+        uvdim: atlas::Size,
+        mut data: Data,
+        clear: bool,
+    ) -> Result<(atlas::PxBox, u8), crate::Error> {
+        // First we check our ID cache to see if there's an existing entry
+        if let Some((cache, uv, layer)) = self.cache.get(&id) {
+            // If we already have data cached, see if it changed. If it didn't, just append the cached data.
+            if data == *cache && uvdim == uv.size() {
+                // To make the cache possible, the data only contains the offset, so we add the region position here.
+                data.pos += uv.min.to_f32().to_array();
+                self.data.entry(*layer).or_default().push(data);
+                return Ok((*uv, *layer));
+            } else if let Some((old, uv, _)) = self.cache.remove(&id) {
+                // Otherwise, we have to delete the cache and decrement the refcount. If the refcount reaches 0,
+                // we delete the region entirely.
+                if let std::collections::hash_map::Entry::Occupied(mut v) =
+                    self.refcount.entry((old, uv.size()))
+                {
+                    if v.get().1 <= 1 {
+                        driver.atlas.write().destroy(&mut v.get_mut().0);
+                        v.remove();
+                    } else {
+                        v.get_mut().1 -= 1;
+                    }
+                }
+            }
+        }
+
+        // If we get this far, either we didn't have something cached, or it had to be replaced. We check to see if the data key
+        // we have is already being used for something else, and increment the refcount if so. Otherwise, we allocate a new region.
+        let (region, _) = match self.refcount.entry((data, uvdim)) {
+            std::collections::hash_map::Entry::Occupied(mut occupied_entry) => {
+                occupied_entry.get_mut().1 += 1;
+                occupied_entry.into_mut()
+            }
+            std::collections::hash_map::Entry::Vacant(vacant_entry) => vacant_entry.insert((
+                driver.atlas.write().reserve(
+                    &driver.device,
+                    uvdim,
+                    None,
+                    if clear { Some(&driver.queue) } else { None },
+                )?,
+                1,
+            )),
+        };
+
+        debug_assert_eq!(uvdim, region.uv.size());
+
+        self.cache
+            .entry(id)
+            .and_modify(|v| *v = (data, region.uv, region.index))
+            .or_insert((data, region.uv, region.index));
+
+        data.pos += region.uv.min.to_f32().to_array();
+        self.data.entry(region.index).or_default().push(data);
+        Ok((region.uv, region.index))
+    }
 }
 
 impl<const KIND: u8> super::Pipeline for Shape<KIND> {
-    type Data = Data;
-
-    fn append(&mut self, data: &Self::Data, layer: u8) {
-        self.data.entry(layer).or_default().push(*data);
-    }
-
     fn draw(&mut self, driver: &graphics::Driver, pass: &mut wgpu::RenderPass<'_>, layer: u8) {
         if let Some(data) = self.data.get_mut(&layer) {
             let size = data.len() * size_of::<Data>();
@@ -374,6 +428,12 @@ impl<const KIND: u8> super::Pipeline for Shape<KIND> {
             pass.set_bind_group(0, &self.group, &[0]);
             pass.draw(0..(data.len() as u32 * 6), 0..1);
             data.clear();
+        }
+    }
+
+    fn destroy(&mut self, driver: &graphics::Driver) {
+        for (_, (mut region, _)) in self.refcount.drain() {
+            driver.atlas.write().destroy(&mut region);
         }
     }
 }
@@ -514,6 +574,8 @@ impl<const KIND: u8> Shape<KIND> {
             buffer,
             pipeline,
             group,
+            cache: HashMap::new(),
+            refcount: HashMap::new(),
         }
     }
 }
@@ -523,7 +585,7 @@ impl Shape<0> {
         layout: &wgpu::PipelineLayout,
         shader: &wgpu::ShaderModule,
         driver: &graphics::Driver,
-    ) -> Box<dyn super::AnyPipeline> {
+    ) -> Box<dyn super::Pipeline> {
         Box::new(Self::new(layout, shader, driver, "rectangle"))
     }
 }
@@ -533,7 +595,7 @@ impl Shape<1> {
         layout: &wgpu::PipelineLayout,
         shader: &wgpu::ShaderModule,
         driver: &graphics::Driver,
-    ) -> Box<dyn super::AnyPipeline> {
+    ) -> Box<dyn super::Pipeline> {
         Box::new(Self::new(layout, shader, driver, "triangle"))
     }
 }
@@ -543,7 +605,7 @@ impl Shape<2> {
         layout: &wgpu::PipelineLayout,
         shader: &wgpu::ShaderModule,
         driver: &graphics::Driver,
-    ) -> Box<dyn super::AnyPipeline> {
+    ) -> Box<dyn super::Pipeline> {
         Box::new(Self::new(layout, shader, driver, "circle"))
     }
 }
@@ -553,7 +615,7 @@ impl Shape<3> {
         layout: &wgpu::PipelineLayout,
         shader: &wgpu::ShaderModule,
         driver: &graphics::Driver,
-    ) -> Box<dyn super::AnyPipeline> {
+    ) -> Box<dyn super::Pipeline> {
         Box::new(Self::new(layout, shader, driver, "arcs"))
     }
 }

--- a/feather-ui/src/resource.rs
+++ b/feather-ui/src/resource.rs
@@ -22,7 +22,7 @@ pub(crate) fn within_variance(l: i32, r: i32, range: f32) -> bool {
 }
 
 /// An empty size request equates to requesting the native size of the image. One axis being zero equates to requesting the
-/// equivelent aspect ratio from tha native aspect ratio.
+/// equivalent aspect ratio from the native aspect ratio.
 #[inline]
 pub fn fill_size(size: atlas::Size, native: atlas::Size) -> atlas::Size {
     match (size.width, size.height) {


### PR DESCRIPTION
This simplifies the pipeline trait by removing the need for AnyPipeline because the Any trait on Pipeline means a downcast can be done for anything that actually knows what pipeline it is requesting, so there doesn't need to be a standardized data append function. This then adds a cache to the shape pipelines to re-use any existing shape parameters.